### PR TITLE
Use hash router instead of browser router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { 
-  BrowserRouter as Router,
+import {
+  HashRouter,
   Switch,
   Route
  } from "react-router-dom";
@@ -12,7 +12,7 @@ import { MapathonSummaryReport } from "./views/MapathonReport";
 
 function App(){
   return (
-    <Router>
+    <HashRouter>
       <Header />
       <div>
       <Switch>
@@ -22,7 +22,7 @@ function App(){
         <Route path="/mapathon-summary-report" component={MapathonSummaryReport}/>
       </Switch>
     </div>
-    </Router>
+    </HashRouter>
   )
 }
 


### PR DESCRIPTION
According to the [create-react-documentation](https://create-react-app.dev/docs/deployment/#notes-on-client-side-routing): GitHub Pages doesn’t support routers that use the HTML5 pushState history API, for example, [react-router's BrowserRouter](https://v5.reactrouter.com/web/api/BrowserRouter).

This PR fixes the routing issues as stated [here](https://github.com/hotosm/galaxy-ui/issues/11) by making use of the [Hash Router](https://v5.reactrouter.com/web/api/HashRouter) instead of the [Browser Router](https://v5.reactrouter.com/web/api/BrowserRouter) functionality. 

