### PR TITLE
Remove the Z at the end of submitted dates

### DIFF
--- a/src/queries/getMapathonSummaryReport.js
+++ b/src/queries/getMapathonSummaryReport.js
@@ -3,8 +3,8 @@ import axios from "axios";
 export const getMapathonSummaryReport = async (requestData) => {
     const { startDate, endDate, TMProjectIds, mapathonHashtags } = requestData;
     let body = {
-        "fromTimestamp": startDate.toISOString(),
-        "toTimestamp": endDate.toISOString(),
+        "fromTimestamp": startDate.toISOString().replace('Z', ''),
+        "toTimestamp": endDate.toISOString().replace('Z', ''),
         "projectIds": [],
         "hashtags": []
     }


### PR DESCRIPTION
Fixes #18 

How to test:
- Create a `.env` file in the base directory.
- Install dependencies using `npm i`
- Add `REACT_APP_API_URL="https://osm-stats.hotosm.org"` and `HOST=127.0.0.1`.
- Run` npm start`.
-  Go to `http://127.0.0.1:3000/#/mapathon-summary-report` to test. 

**Screenshot:** 

<img width="1425" alt="Screenshot 2021-11-26 at 16 31 42" src="https://user-images.githubusercontent.com/31903212/143588610-f7d582a9-a278-4430-a3df-d7f23d2f68fd.png">

_**Payload passed to API in above screenshot/example:**_
```
{
    "fromTimestamp": "2021-08-27T09:00:00.000",
    "toTimestamp": "2021-08-27T10:00:00.000",
    "projectIds": [11224,10042],
    "hashtags": [ "mapandchathour2021"]
}
```