### PR TITLE
Fix time difference validation and display server errors

### DIFF
--- a/src/components/formResponse.js
+++ b/src/components/formResponse.js
@@ -3,6 +3,50 @@ import { FormattedMessage } from 'react-intl';
 import { BanIcon } from '../assets/svgIcons';
 import messages from './messages';
 
+const ErrorMessage = ({message}) => {
+    if (message === "Missing fields") {
+        return (
+            <>
+            <FormattedMessage
+                {...messages.mapathonSummaryErrorEmptyFields}
+                values={{
+                    b: chunks => <b>{chunks}</b>
+                }}
+            />
+            <li>
+                <FormattedMessage {...messages.mapathonSummaryFormProjectIds} />
+            </li>
+            <li>
+            <FormattedMessage {...messages.mapathonSummaryFormHashtags} />
+            </li>  
+        </>
+        )
+    } else if(message === 'Invalid IDs') {
+        return (
+            <p>
+                <FormattedMessage {...messages.mapathonSummaryErrorInvalidIds}/>
+            </p>
+        )
+    } else if (message === 'Invalid Time') {
+        return (
+            <p>
+                <FormattedMessage {...messages.mapathonSummaryErrorInvalidTime}/>
+            </p>
+        )
+    } else {
+        return (
+             <FormattedMessage
+                {...messages.mapathonSummaryServerError}
+                values={{
+                    error: (
+                        <span className="text-red">{message}</span>  
+                    )
+                }}
+            />
+        )
+    }
+};
+
 export function Error({error}) {
     return (
         <div className="bg-red-light mt-5 mx-auto w-1/4 text-lg p-4">
@@ -11,37 +55,7 @@ export function Error({error}) {
                 <FormattedMessage {...messages.mapathonSummaryErrorTitle}/>
             </h5>
             <div className="mt-3">
-            {error === "Missing fields" && (
-                <>
-                    <FormattedMessage
-                        {...messages.mapathonSummaryErrorEmptyFields}
-                        values={{
-                            b: chunks => <b>{chunks}</b>
-                        }}
-                    />
-                    <li>
-                        <FormattedMessage {...messages.mapathonSummaryFormProjectIds} />
-                    </li>
-                    <li>
-                    <FormattedMessage {...messages.mapathonSummaryFormHashtags} />
-                    </li>  
-                </>
-            )}
-            {error === 'Invalid IDs' && (
-                <p>
-                    <FormattedMessage {...messages.mapathonSummaryErrorInvalidIds}/>
-                </p>
-            )}
-            {error === 'Invalid Time' && (
-                <p>
-                    <FormattedMessage {...messages.mapathonSummaryErrorInvalidTime}/>
-                </p>
-            )}
-            {error === 'Server Error' && (
-                <p>
-                    <FormattedMessage {...messages.mapathonSummaryServerError}/>
-                </p>
-            )}
+                <ErrorMessage message={error}/>
             </div>
         </div>
     )

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -69,7 +69,6 @@ export const MapathonReportForm = ({fetch, error}) => {
                               });
                           }}
                           showTimeSelect
-                          timeFormat="HH:mm"
                           timeIntervals={15}
                           timeCaption="Time"
                           dateFormat="d MMMM, yyyy h:mm aa"
@@ -91,7 +90,6 @@ export const MapathonReportForm = ({fetch, error}) => {
                           }}
                           minDate={formData.startDate}
                           showTimeSelect
-                          timeFormat="HH:mm"
                           timeIntervals={15}
                           timeCaption="Time"
                           dateFormat=" d MMMM, yyyy h:mm aa"

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -87,7 +87,7 @@ export default defineMessages({
     },
     mapathonSummaryServerError: {
         id: 'reports.mapathon.summary.form.error.server',
-        defaultMessage: "There was a server error while executing this query. Please try again later."
+        defaultMessage: "There was a problem with the server - {error} while executing this query. Please try again later."
     },
     footerOrganisation: {
         id: 'about.footer.organisation',

--- a/src/utils/tests/validationUtils.test.js
+++ b/src/utils/tests/validationUtils.test.js
@@ -1,0 +1,62 @@
+import { add } from "date-fns";
+import { validateDateDifference, validateNumberInput } from '../validationUtils';
+
+describe("validateDateDifference tests", () => {
+  test('dates with 1 hour time difference for 24 hours max difference passes', () => {
+    let date1 = add(new Date(), {hours: -1});
+    let date2 = new Date();
+    expect(validateDateDifference(date1, date2, 24)).toEqual(true);
+  })
+  
+  test('dates with 1/2 hour time difference for 24 hours max difference passes', () => {
+    let date1 = add(new Date(), {minutes: -30});
+    let date2 = new Date();
+    expect(validateDateDifference(date1, date2, 24)).toEqual(true);
+  });
+  
+  test('dates with 2 minutes time difference for 24 hours max difference passes', () => {
+    let date1 = add(new Date(), {minutes: -2});
+    let date2 = new Date();
+    expect(validateDateDifference(date1, date2, 24)).toEqual(true);
+  });
+  
+  test('dates with 25 hour difference for 24 hours max difference fails', () => {
+    let date1 = add(new Date(), {days: -1, hours: -1});
+    let date2 = new Date();
+    expect(validateDateDifference(date1, date2, 24)).toEqual(false);
+  });
+  
+  test('dates with the start date later than end date fails', () => {
+    let date1 = add(new Date(), {hours: -1});
+    let date2 = new Date();
+    expect(validateDateDifference(date2, date1, 24)).toEqual(false);
+  });
+  
+  test('dates where the times of the dates is equal fails', () => {
+    let date1 = new Date();
+    let date2 = new Date();
+    expect(validateDateDifference(date2, date1, 24)).toEqual(false);
+  });
+});
+
+describe("validateNumberInputs", () => {
+  test("string input of numbers passes", () => {
+     let input = "1,2,3,4,5";
+     expect(validateNumberInput(input)).toEqual(true);
+  });
+
+  test("string input of alphanumeric characters fails", () => {
+    let input = "1,alpha, 2, beta";
+    expect(validateNumberInput(input)).toEqual(false);
+  });
+
+  test("string input of words fails", () => {
+    let input = "alpha, beta";
+    expect(validateNumberInput(input)).toEqual(false);
+  });
+
+  test("string input of single number passes", () => {
+    let input = "2";
+    expect(validateNumberInput(input)).toEqual(true);
+  });
+});

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -1,0 +1,37 @@
+import { differenceInMinutes } from "date-fns";
+
+export const validateDateDifference = (startDate, endDate, timeInHours) => {
+  let valid = false
+  if ((differenceInMinutes(endDate, startDate) <= (timeInHours*60)) && differenceInMinutes(endDate, startDate) > 0){
+    valid = true;
+  }
+  return valid;
+};
+
+export const validateNumberInput = (input) => {
+  let valid = true;
+  if (input.length > 0) {
+    if (input.split(',').every(i => Number.isInteger(Number(i)))) {
+      valid = true;
+    } else {
+      valid = false;
+    }
+  }
+  return valid;
+};
+
+export const validateMapathonFormData = (formInputs) => {
+  const { startDate, endDate, TMProjectIds, mapathonHashtags } = formInputs;
+
+  let validDate = validateDateDifference(startDate, endDate, 24);
+  if(!validDate) throw new Error("Invalid Time");
+ 
+  if (TMProjectIds.length === 0 && mapathonHashtags.length === 0) {
+    throw new Error("Missing fields");
+  }
+  
+  let validIds = validateNumberInput(TMProjectIds);
+  if(!validIds) throw new Error("Invalid IDs");
+
+  return validDate && validIds;
+};

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -17,7 +17,7 @@ export const MapathonSummaryReport = (props) => {
     return (
         <div>
             <MapathonReportForm
-                  error={error ? 'Server Error' : null}
+                  error={error ? error.message : null}
                   fetch={mutate}
               />
             <AuthorisationButton origin={"mapathon"} redirectTo={props.location.pathname}/>
@@ -37,7 +37,7 @@ export const MapathonDetailedReport = () => {
         return (
             <div>
                 <MapathonReportForm
-                    error={error ? 'Server Error' : null}
+                    error={error ? error.message : null}
                     fetch={mutate}
                 />
                 {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
@@ -51,4 +51,4 @@ export const MapathonDetailedReport = () => {
             </div>
         )
     }
-  }  
+};


### PR DESCRIPTION
This PR fixes #23 and shows relevant error messages returned by the backend server when a request fails.

**Tasks done:**
- Add reusable validation functions for each form inputs
- Add tests for validation functions.

**How to test:**
- Create a `.env` file in the base directory.
- Install dependencies using `npm i`
- Add `REACT_APP_API_URL="https://osm-stats.hotosm.org"` and `HOST=127.0.0.1`.
- Run `npm start`. Go to `http://127.0.0.1:3000/#/mapathon-summary-report` to test the app. For example, start date and end date with a time difference of less than 59 minutes. 

**Screenshots:**
- Fetching results for a 6 minute duration mapathon summary report:
<img width="1427" alt="6 min " src="https://user-images.githubusercontent.com/31903212/147547149-92726744-df29-43dc-b765-45f14674960a.png">

- display time in 12-hour clock format in date picker sections:
<img width="359" alt="12 hour clock format" src="https://user-images.githubusercontent.com/31903212/147547119-59994a94-fa8b-4817-bc90-b1a4e5490134.png">

