### PR TITLE
Improve Mapathon Summary and Detailed Report Pages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "prepare": "husky install"
   },
   "eslintConfig": {
     "extends": [

--- a/src/App.js
+++ b/src/App.js
@@ -15,30 +15,35 @@ import {
 import { UserGroupReport } from "./views/UserGroupReport";
 import { MapathonContextProvider } from "./context/mapathonContext";
 
-
-function App(){
+function App() {
   return (
     <>
       <Router>
-      <Header />
-      <div>
-        <Switch>
-          <Route exact path="/" component={Home} />
-          <Route path="/authorised" component={LoginCallback} />
-          <Route path="/about" component={About} />
-          <Route path="/explore" component={Reports}/>
-          <ProtectedRoute path={"/user-report"}>
-            <UserGroupReport />
-          </ProtectedRoute>
-        </Switch>
-        <Switch>
-          <MapathonContextProvider>
-            <Route path="/mapathon-report/summary" component={MapathonSummaryReport}/>
-            <Route path="/mapathon-report/detailed" component={MapathonDetailedReport} />
-          </MapathonContextProvider>
-        </Switch>
-      </div>
-    </Router>
+        <Header />
+        <div>
+          <Switch>
+            <Route exact path="/" component={Home} />
+            <Route path="/authorised" component={LoginCallback} />
+            <Route path="/about" component={About} />
+            <Route path="/explore" component={Reports} />
+            <ProtectedRoute path={"/user-report"}>
+              <UserGroupReport />
+            </ProtectedRoute>
+          </Switch>
+          <Switch>
+            <MapathonContextProvider>
+              <Route
+                path="/mapathon-report/summary"
+                component={MapathonSummaryReport}
+              />
+              <Route
+                path="/mapathon-report/detailed"
+                component={MapathonDetailedReport}
+              />
+            </MapathonContextProvider>
+          </Switch>
+        </div>
+      </Router>
       {MATOMO_ID && <TrackingBanner />}
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -13,33 +13,32 @@ import {
   MapathonDetailedReport,
 } from "./views/MapathonReports";
 import { UserGroupReport } from "./views/UserGroupReport";
+import { MapathonContextProvider } from "./context/mapathonContext";
 
 
 function App(){
   return (
     <>
       <Router>
-        <Header />
-        <div>
-          <Switch>
-            <Route exact path="/" component={Home} />
-            <Route path="/authorised" component={LoginCallback} />
-            <Route path="/about" component={About} />
-            <Route path="/explore" component={Reports} />
-            <Route
-              path="/mapathon-report/summary"
-              component={MapathonSummaryReport}
-            />
-            <Route
-              path="/mapathon-report/detailed"
-              component={MapathonDetailedReport}
-            />
-            <ProtectedRoute path={"/user-report"}>
-              <UserGroupReport />
-            </ProtectedRoute>
-          </Switch>
-        </div>
-      </Router>
+      <Header />
+      <div>
+        <Switch>
+          <Route exact path="/" component={Home} />
+          <Route path="/authorised" component={LoginCallback} />
+          <Route path="/about" component={About} />
+          <Route path="/explore" component={Reports}/>
+          <ProtectedRoute path={"/user-report"}>
+            <UserGroupReport />
+          </ProtectedRoute>
+        </Switch>
+        <Switch>
+          <MapathonContextProvider>
+            <Route path="/mapathon-report/summary" component={MapathonSummaryReport}/>
+            <Route path="/mapathon-report/detailed" component={MapathonDetailedReport} />
+          </MapathonContextProvider>
+        </Switch>
+      </div>
+    </Router>
       {MATOMO_ID && <TrackingBanner />}
     </>
   );

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,9 +2,9 @@ import * as safeStorage from "../utils/safeStorage";
 
 const initialAppState = {
   auth: {
-      loggedIn: safeStorage.getItem("loggedIn"),
-      accessToken: safeStorage.getItem("token"),
-  }
+    loggedIn: safeStorage.getItem("loggedIn"),
+    accessToken: safeStorage.getItem("token"),
+  },
 };
 
 export const saveState = (state) => {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,17 +2,9 @@ import * as safeStorage from "../utils/safeStorage";
 
 const initialAppState = {
   auth: {
-    loggedIn: safeStorage.getItem("loggedIn"),
-    accessToken: safeStorage.getItem("token"),
-  },
-  form: {
-    projectIds: safeStorage.getItem("projectIds")
-      ? safeStorage.getItem("projectIds")
-      : "",
-    hashtags: safeStorage.getItem("hashtags")
-      ? safeStorage.getItem("hashtags")
-      : "",
-  },
+      loggedIn: safeStorage.getItem("loggedIn"),
+      accessToken: safeStorage.getItem("token"),
+  }
 };
 
 export const saveState = (state) => {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,14 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { saveState, loadState } from "./state";
-import authReducer from "../features/auth/authorisationSlice";
-import formReducer from "../features/form/formDataSlice";
+import authReducer from '../features/auth/authorisationSlice';
 
 const store = configureStore({
-  reducer: {
-    auth: authReducer,
-    form: formReducer,
-  },
-  preloadedState: loadState(),
+    reducer: {
+        auth: authReducer,
+    },
+    preloadedState: loadState(),
 });
 
 store.subscribe(() => {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,12 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { saveState, loadState } from "./state";
-import authReducer from '../features/auth/authorisationSlice';
+import authReducer from "../features/auth/authorisationSlice";
 
 const store = configureStore({
-    reducer: {
-        auth: authReducer,
-    },
-    preloadedState: loadState(),
+  reducer: {
+    auth: authReducer,
+  },
+  preloadedState: loadState(),
 });
 
 store.subscribe(() => {

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -8,15 +8,17 @@ export function Button({ children, onClick, styles }) {
   );
 }
 
-export function SubmitButton({ children, styles }) {
+export function SubmitButton({ children, styles, disabled}) {
   return (
     <button
       type="submit"
       aria-pressed="false"
       focusindex="0"
       className={styles}
+      disabled={disabled}
     >
       {children}
     </button>
   );
 }
+  

--- a/src/components/mapathon/mapathonError.js
+++ b/src/components/mapathon/mapathonError.js
@@ -4,36 +4,36 @@ import messages from "../messages";
 
 export const MapathonErrorMessage = ({ error }) => {
   if (error === "Missing fields") {
-    return (
-      <>
-        <FormattedMessage
-          {...messages.mapathonSummaryErrorEmptyFields}
-          values={{
-            b: (chunks) => <b>{chunks}</b>,
-          }}
-        />
-        <li>
-          <FormattedMessage {...messages.mapathonSummaryFormProjectIds} />
-        </li>
-        <li>
-          <FormattedMessage {...messages.mapathonSummaryFormHashtags} />
-        </li>
+      return (
+          <>
+          <FormattedMessage
+              {...messages.mapathonFormErrorEmptyFields}
+              values={{
+                  b: chunks => <b>{chunks}</b>
+              }}
+          />
+          <li>
+              <FormattedMessage {...messages.mapathonFormProjectIds} />
+          </li>
+          <li>
+          <FormattedMessage {...messages.mapathonFormHashtags} />
+          </li>  
       </>
-    );
-  } else if (error === "Invalid IDs") {
-    return (
-      <p>
-        <FormattedMessage {...messages.mapathonSummaryErrorInvalidIds} />
-      </p>
-    );
-  } else if (error === "Invalid Time") {
-    return (
-      <p>
-        <FormattedMessage {...messages.mapathonSummaryErrorInvalidTime} />
-      </p>
-    );
+      )
+  } else if(error === 'Invalid IDs') {
+      return (
+          <p>
+              <FormattedMessage {...messages.mapathonFormErrorInvalidIds}/>
+          </p>
+      )
+  } else if (error === 'Invalid Time') {
+      return (
+          <p>
+              <FormattedMessage {...messages.mapathonFormErrorInvalidTime}/>
+          </p>
+      )
   } else {
-    return (
+      return (
       <FormattedMessage
         {...messages.ServerError}
         values={{

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -51,83 +51,79 @@ export const MapathonReportForm = ({ fetch, error }) => {
     }
   };
 
-  return (
-    <>
-      <form onSubmit={handleSubmit} className="mt-4 px-4">
-        <div className="grid grid-cols-8 gap-4">
-          <div className="space-y-20 py-2 col-span-2">
-            <div className="text-xl">
-              <label>
-                <span className="text-red">* </span>
-                <FormattedMessage {...messages.mapathonSummaryFormStartDate} />:
-              </label>
-              <DatePicker
-                selected={formData.startDate}
-                onChange={(date) => {
-                  setFormData({
-                    ...formData,
-                    startDate: date,
-                  });
-                }}
-                showTimeSelect
-                timeIntervals={15}
-                timeCaption="Time"
-                dateFormat="d MMMM, yyyy h:mm aa"
-                className="w-full p-2 block  border border-grey-light mt-5"
-              />
-            </div>
-            <div className="text-xl">
-              <label>
-                <span className="text-red">* </span>
-                <FormattedMessage {...messages.mapathonSummaryFormEndDate} />:
-              </label>
-              <DatePicker
-                selected={formData.endDate}
-                onChange={(date) => {
-                  setFormData({
-                    ...formData,
-                    endDate: date,
-                  });
-                }}
-                minDate={formData.startDate}
-                showTimeSelect
-                timeIntervals={15}
-                timeCaption="Time"
-                dateFormat=" d MMMM, yyyy h:mm aa"
-                className="w-full p-2 block  border border-grey-light mt-5"
-              />
-            </div>
-          </div>
-          <div className="flex flex-col py-2 col-span-3 text-xl">
-            <label>
-              <FormattedMessage {...messages.mapathonSummaryFormProjectIds} />:
-            </label>
-            <textarea
-              name="TMProjectIds"
-              rows="7"
-              placeholder={intl.formatMessage(
-                messages.mapathonSummaryFormIdsPlaceholder
-              )}
-              value={formData.TMProjectIds}
-              onChange={handleChange}
-              className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
-            />
-          </div>
-          <div className="flex flex-col py-2 col-span-3 text-xl">
-            <label>
-              <FormattedMessage {...messages.mapathonSummaryFormHashtags} />:
-            </label>
-            <textarea
-              name="mapathonHashtags"
-              rows="7"
-              placeholder={intl.formatMessage(
-                messages.mapathonSummaryFormHashtagsPlaceholder
-              )}
-              value={formData.mapathonHashtags}
-              onChange={handleChange}
-              className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
-            />
-          </div>
+    return (
+      <>
+        <form onSubmit={handleSubmit} className="mt-4 px-4">
+          <div className="grid grid-cols-8 gap-4">
+              <div className="space-y-20 py-2 col-span-2">
+                  <div className="text-xl">
+                      <label>
+                          <span className="text-red">* </span>
+                          <FormattedMessage {...messages.mapathonFormStartDate}/>:
+                      </label>
+                      <DatePicker
+                          selected={formData.startDate}
+                          onChange={(date) => {
+                              setFormData({
+                                  ...formData,
+                                  startDate: date
+                              });
+                          }}
+                          showTimeSelect
+                          timeIntervals={15}
+                          timeCaption="Time"
+                          dateFormat="d MMMM, yyyy h:mm aa"
+                          className="w-full p-2 block  border border-grey-light mt-5"
+                      />
+                  </div>
+                  <div className="text-xl">
+                      <label>
+                          <span className="text-red">* </span>
+                          <FormattedMessage {...messages.mapathonFormEndDate}/>:
+                      </label>
+                      <DatePicker
+                          selected={formData.endDate}
+                          onChange={(date) => {
+                              setFormData({
+                                  ...formData,
+                                  endDate: date
+                              });
+                          }}
+                          minDate={formData.startDate}
+                          showTimeSelect
+                          timeIntervals={15}
+                          timeCaption="Time"
+                          dateFormat=" d MMMM, yyyy h:mm aa"
+                          className="w-full p-2 block  border border-grey-light mt-5"
+                      />
+                  </div>
+              </div>
+              <div className="flex flex-col py-2 col-span-3 text-xl">
+                  <label>
+                  <FormattedMessage {...messages.mapathonFormProjectIds}/>:
+                  </label>
+                  <textarea
+                      name="TMProjectIds"
+                      rows="7"
+                      placeholder={intl.formatMessage(messages.mapathonFormIdsPlaceholder)}
+                      value={formData.TMProjectIds}
+                      onChange={handleChange}
+                      className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
+                  /> 
+              </div>
+              <div className="flex flex-col py-2 col-span-3 text-xl">
+                  <label>
+                      <FormattedMessage {...messages.mapathonFormHashtags}/>:
+                  </label>
+                  <textarea
+                      name="mapathonHashtags"
+                      rows="7"
+                      placeholder={intl.formatMessage(messages.mapathonFormHashtagsPlaceholder)}
+                      value={formData.mapathonHashtags}
+                      onChange={handleChange}
+                      className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
+                  />
+              </div>
         </div>
         <div className="text-center mt-4">
           <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -1,26 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import DatePicker from "react-datepicker";
-import { addHours } from "date-fns";
-import { useSelector, useDispatch } from "react-redux";
 import { FormattedMessage, useIntl } from "react-intl";
 import "react-datepicker/dist/react-datepicker.css";
 import { SubmitButton } from "../button";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
 import messages from "../messages";
-import { validateMapathonFormData } from "../../utils/validationUtils";
-import { setProjectIds, setHashtags } from "../../features/form/formDataSlice";
+import { validateMapathonFormData } from '../../utils/validationUtils';
+import { MapathonContext } from "../../context/mapathonContext";
 
 export const MapathonReportForm = ({ fetch, error }) => {
   const intl = useIntl();
-  const dispatch = useDispatch();
 
-  const [formData, setFormData] = useState({
-    startDate: addHours(new Date(), -1),
-    endDate: new Date(),
-    TMProjectIds: useSelector((state) => state.form.projectIds),
-    mapathonHashtags: useSelector((state) => state.form.hashtags),
-  });
+const { formData, setFormData } = useContext(MapathonContext)
 
   const [formError, setFormError] = useState(null);
 
@@ -39,13 +31,11 @@ export const MapathonReportForm = ({ fetch, error }) => {
   const handleSubmit = (event) => {
     event.preventDefault();
     try {
-      let isValid = validateMapathonFormData(formData);
-      if (isValid) {
-        dispatch(setProjectIds(formData.TMProjectIds));
-        dispatch(setHashtags(formData.mapathonHashtags));
-        fetch(formData); // API call
-        setFormError(null);
-      }
+        let isValid = validateMapathonFormData(formData)
+        if (isValid) {
+            fetch(formData); // API call
+            setFormError(null);
+        }
     } catch (e) {
       setFormError(e.message);
     }
@@ -94,7 +84,7 @@ export const MapathonReportForm = ({ fetch, error }) => {
                           timeIntervals={15}
                           timeCaption="Time"
                           dateFormat=" d MMMM, yyyy h:mm aa"
-                          className="w-full p-2 block  border border-grey-light mt-5"
+                          className="w-full p-2 block border border-grey-light mt-5"
                       />
                   </div>
               </div>
@@ -124,14 +114,14 @@ export const MapathonReportForm = ({ fetch, error }) => {
                       className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
                   />
               </div>
-        </div>
-        <div className="text-center mt-4">
-          <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">
-            Submit Your Query
-          </SubmitButton>
-        </div>
-      </form>
-      {formError && (
+          </div>
+          <div className="text-center mt-4">
+              <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">
+                  <FormattedMessage {...messages.mapathonSubmitForm}/>
+              </SubmitButton>
+          </div>
+        </form>
+        {formError && (
         <Error>
           <MapathonErrorMessage error={formError} />
         </Error>

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -1,18 +1,19 @@
 import React, { useState, useEffect, useContext } from "react";
 import DatePicker from "react-datepicker";
+import { getTime } from "date-fns";
 import { FormattedMessage, useIntl } from "react-intl";
 import "react-datepicker/dist/react-datepicker.css";
 import { SubmitButton } from "../button";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
 import messages from "../messages";
-import { validateMapathonFormData } from '../../utils/validationUtils';
+import { validateMapathonFormData } from "../../utils/validationUtils";
 import { MapathonContext } from "../../context/mapathonContext";
 
-export const MapathonReportForm = ({fetch, error, loading}) => {
+export const MapathonReportForm = ({ fetch, error, loading }) => {
   const intl = useIntl();
 
-const { formData, setFormData } = useContext(MapathonContext)
+  const { formData, setFormData } = useContext(MapathonContext);
 
   const [formError, setFormError] = useState(null);
 
@@ -31,97 +32,107 @@ const { formData, setFormData } = useContext(MapathonContext)
   const handleSubmit = (event) => {
     event.preventDefault();
     try {
-        let isValid = validateMapathonFormData(formData)
-        if (isValid) {
-            fetch(formData); // API call
-            setFormError(null);
-        }
+      let isValid = validateMapathonFormData(formData);
+      if (isValid) {
+        fetch(formData); // API call
+        setFormError(null);
+      }
     } catch (e) {
       setFormError(e.message);
     }
   };
 
-    return (
-      <>
-        <form onSubmit={handleSubmit} className="mt-4 px-4">
-          <div className="grid grid-cols-8 gap-4">
-              <div className="space-y-20 py-2 col-span-2">
-                  <div className="text-xl">
-                      <label>
-                          <span className="text-red">* </span>
-                          <FormattedMessage {...messages.mapathonFormStartDate}/>:
-                      </label>
-                      <DatePicker
-                          selected={formData.startDate}
-                          onChange={(date) => {
-                              setFormData({
-                                  ...formData,
-                                  startDate: date
-                              });
-                          }}
-                          showTimeSelect
-                          timeIntervals={15}
-                          timeCaption="Time"
-                          dateFormat="d MMMM, yyyy h:mm aa"
-                          className="w-full p-2 block  border border-grey-light mt-5"
-                      />
-                  </div>
-                  <div className="text-xl">
-                      <label>
-                          <span className="text-red">* </span>
-                          <FormattedMessage {...messages.mapathonFormEndDate}/>:
-                      </label>
-                      <DatePicker
-                          selected={formData.endDate}
-                          onChange={(date) => {
-                              setFormData({
-                                  ...formData,
-                                  endDate: date
-                              });
-                          }}
-                          minDate={formData.startDate}
-                          showTimeSelect
-                          timeIntervals={15}
-                          timeCaption="Time"
-                          dateFormat=" d MMMM, yyyy h:mm aa"
-                          className="w-full p-2 block border border-grey-light mt-5"
-                      />
-                  </div>
-              </div>
-              <div className="flex flex-col py-2 col-span-3 text-xl">
-                  <label>
-                  <FormattedMessage {...messages.mapathonFormProjectIds}/>:
-                  </label>
-                  <textarea
-                      name="TMProjectIds"
-                      rows="7"
-                      placeholder={intl.formatMessage(messages.mapathonFormIdsPlaceholder)}
-                      value={formData.TMProjectIds}
-                      onChange={handleChange}
-                      className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
-                  /> 
-              </div>
-              <div className="flex flex-col py-2 col-span-3 text-xl">
-                  <label>
-                      <FormattedMessage {...messages.mapathonFormHashtags}/>:
-                  </label>
-                  <textarea
-                      name="mapathonHashtags"
-                      rows="7"
-                      placeholder={intl.formatMessage(messages.mapathonFormHashtagsPlaceholder)}
-                      value={formData.mapathonHashtags}
-                      onChange={handleChange}
-                      className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
-                  />
-              </div>
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="mt-4 px-4">
+        <div className="grid grid-cols-8 gap-4">
+          <div className="space-y-20 py-2 col-span-2">
+            <div className="text-xl">
+              <label>
+                <span className="text-red">* </span>
+                <FormattedMessage {...messages.mapathonFormStartDate} />:
+              </label>
+              <DatePicker
+                selected={formData.startDate}
+                onChange={(date) => {
+                  setFormData({
+                    ...formData,
+                    startDate: date,
+                  });
+                }}
+                showTimeSelect
+                timeIntervals={15}
+                timeCaption="Time"
+                dateFormat="d MMMM, yyyy h:mm aa"
+                className="w-full p-2 block  border border-grey-light mt-5"
+              />
+            </div>
+            <div className="text-xl">
+              <label>
+                <span className="text-red">* </span>
+                <FormattedMessage {...messages.mapathonFormEndDate} />:
+              </label>
+              <DatePicker
+                selected={formData.endDate}
+                onChange={(date) => {
+                  setFormData({
+                    ...formData,
+                    endDate: date,
+                  });
+                }}
+                minDate={formData.startDate}
+                filterTime={(time) =>
+                  getTime(formData.startDate) < getTime(time)
+                }
+                showTimeSelect
+                timeIntervals={15}
+                timeCaption="Time"
+                dateFormat=" d MMMM, yyyy h:mm aa"
+                className="w-full p-2 block border border-grey-light mt-5"
+              />
+            </div>
           </div>
-          <div className="text-center mt-4">
-              <SubmitButton styles="bg-red text-white py-3 px-10 text-xl" disabled={loading}>
-                  <FormattedMessage {...messages.mapathonSubmitForm}/>
-              </SubmitButton>
+          <div className="flex flex-col py-2 col-span-3 text-xl">
+            <label>
+              <FormattedMessage {...messages.mapathonFormProjectIds} />:
+            </label>
+            <textarea
+              name="TMProjectIds"
+              rows="7"
+              placeholder={intl.formatMessage(
+                messages.mapathonFormIdsPlaceholder
+              )}
+              value={formData.TMProjectIds}
+              onChange={handleChange}
+              className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
+            />
           </div>
-        </form>
-        {formError && (
+          <div className="flex flex-col py-2 col-span-3 text-xl">
+            <label>
+              <FormattedMessage {...messages.mapathonFormHashtags} />:
+            </label>
+            <textarea
+              name="mapathonHashtags"
+              rows="7"
+              placeholder={intl.formatMessage(
+                messages.mapathonFormHashtagsPlaceholder
+              )}
+              value={formData.mapathonHashtags}
+              onChange={handleChange}
+              className="mt-5 blue-grey w-100 py-3 px-2 border border-grey-light bg-transparent focus:outline-none resize-none"
+            />
+          </div>
+        </div>
+        <div className="text-center mt-4">
+          <SubmitButton
+            styles="bg-red text-white py-3 px-10 text-xl"
+            disabled={loading}
+          >
+            <FormattedMessage {...messages.mapathonSubmitForm} />
+          </SubmitButton>
+        </div>
+      </form>
+      {formError && (
         <Error>
           <MapathonErrorMessage error={formError} />
         </Error>

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -9,7 +9,7 @@ import messages from "../messages";
 import { validateMapathonFormData } from '../../utils/validationUtils';
 import { MapathonContext } from "../../context/mapathonContext";
 
-export const MapathonReportForm = ({ fetch, error }) => {
+export const MapathonReportForm = ({fetch, error, loading}) => {
   const intl = useIntl();
 
 const { formData, setFormData } = useContext(MapathonContext)
@@ -116,7 +116,7 @@ const { formData, setFormData } = useContext(MapathonContext)
               </div>
           </div>
           <div className="text-center mt-4">
-              <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">
+              <SubmitButton styles="bg-red text-white py-3 px-10 text-xl" disabled={loading}>
                   <FormattedMessage {...messages.mapathonSubmitForm}/>
               </SubmitButton>
           </div>

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -57,16 +57,33 @@ export const MapathonSummaryResults = ({ data }) => {
     </div>
   );
 };
+const MAPATHON_DETAILED_COLUMN_HEADINGS= [
+    { title: "Mapper" }, 
+    { title: "AddedBuildings" }, 
+    { title: "ModifiedBuildings" }, 
+    { title: "AddedHighways" }, 
+    { title: "MappedTasks" },
+    { title: "ValidatedTasks" }
+];
 
-export const TableResults = ({data}) => {
-    const headings = ["Mapper", "Buildings Added", "Buildings Modified", "Highways Added","Tasks Mapped", "Tasks Validated"];
+
+export const MapathonDetailedResults = ({data}) => {
     const { mappedFeatures, contributors } = data
     if (mappedFeatures.length > 0 && contributors.length > 0) {
         return (
             <table className="table-fixed mt-5 mx-auto">
                 <thead>
                     <tr>
-                        {headings.map((i, n) => <th key={n} className="w-1/6 text-left font-normal text-xl px-7 py-4">{i}</th>)}
+                        {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
+                            return(
+                                <th 
+                                    key={n} 
+                                    className="w-1/6 text-left font-normal text-xl px-7 py-4"
+                                >
+                                    <FormattedMessage {...messages[i.title]} />
+                                </th> 
+                            )}
+                        )}
                     </tr>
                 </thead>
                 <tbody>

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -58,60 +58,44 @@ export const MapathonSummaryResults = ({ data }) => {
   );
 };
 
-export const TableResults = ({ data }) => {
-  const headings = [
-    "Mapper",
-    "Buildings Added",
-    "Buildings Modified",
-    "Highway (Km) Added",
-    "Tasks Mapped",
-    "Tasks Validated",
-  ];
-  const { mappedFeatures, contributors } = data;
-  if (mappedFeatures.length > 0 && contributors.length > 0) {
-    return (
-      <table className="table-fixed mt-5 mx-auto">
-        <thead>
-          <tr>
-            {headings.map((i, n) => (
-              <th
-                key={n}
-                className="w-1/6 text-left font-normal text-xl px-7 py-4"
-              >
-                {i}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sortUserData(data).map((i) => (
-            <tr key={i["userId"]}>
-              <td className="py-2 px-7 text-lg">
-                <NavLink
-                  to={{
-                    pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
-                  }}
-                  target="_blank"
-                  className="hover:underline"
-                >
-                  {i["username"]}
-                </NavLink>
-              </td>
-              <td className="py-2 px-7 text-lg">{i["totalBuildings"]}</td>
-              <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
-              <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
-              <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
-              <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    );
-  } else {
-    return (
-      <div className="mx-auto text-center w-1/4 p-1 mt-5">
-        <p className="text-lg">No data found!</p>
-      </div>
-    );
-  }
+export const TableResults = ({data}) => {
+    const headings = ["Mapper", "Buildings Added", "Buildings Modified", "Highways Added","Tasks Mapped", "Tasks Validated"];
+    const { mappedFeatures, contributors } = data
+    if (mappedFeatures.length > 0 && contributors.length > 0) {
+        return (
+            <table className="table-fixed mt-5 mx-auto">
+                <thead>
+                    <tr>
+                        {headings.map((i, n) => <th key={n} className="w-1/6 text-left font-normal text-xl px-7 py-4">{i}</th>)}
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortUserData(data).map((i) => (
+                        <tr key={i["userId"]}>
+                            <td className="py-2 px-7 text-lg">
+                                <NavLink
+                                to={{ pathname:`https://www.openstreetmap.org/user/${i["username"]}`}}
+                                target="_blank"
+                                className="hover:underline"
+                                >
+                                    {i["username"]}
+                                </NavLink>
+                            </td>
+                            <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
+                            <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
+                            <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
+                            <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
+                            <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        )
+    } else {
+        return (
+            <div className="mx-auto text-center w-1/4 p-1 mt-5">
+                <p className="text-lg">No data found!</p>
+            </div>
+        );
+    }
 };

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,30 +1,31 @@
-import React, { useContext, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
-import { sortUserData } from '../../utils/sortMapathonResultsData';
-import messages from '../messages';
+import React, { useContext, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { NavLink } from "react-router-dom";
+import { sortUserData } from "../../utils/sortMapathonResultsData";
+import messages from "../messages";
 import { MapathonContext } from "../../context/mapathonContext";
-import { DownloadFileLink } from '../downloadLink';
-import { Error } from '../formResponses';
-import { MapathonErrorMessage } from './mapathonError';
+import { DownloadFileLink } from "../downloadLink";
+import { Error } from "../formResponses";
+import { MapathonErrorMessage } from "./mapathonError";
 
 const FeatureList = ({ title, features }) => {
-    return (
-        <div className="w-auto">
-            <h2 className="text-2xl py-2 font-bold">
-                {title}:
-            </h2>
-            {features && features.length > 0 ? (
-                <ul>
-                {features && features.map((item, n) =>
-                    <li key={n}>
-                        <p className="text-xl">{item.feature}: {item.count}</p>  
-                    </li>
-                )}
-            </ul>
-            ): (
-                <p>
-                    <FormattedMessage {...messages.mapathonSummaryZeroFeatures}/>
+  return (
+    <div className="w-auto">
+      <h2 className="text-2xl py-2 font-bold">{title}:</h2>
+      {features && features.length > 0 ? (
+        <ul>
+          {features &&
+            features.map((item, n) => (
+              <li key={n}>
+                <p className="text-xl">
+                  {item.feature}: {item.count}
+                </p>
+              </li>
+            ))}
+        </ul>
+      ) : (
+        <p>
+          <FormattedMessage {...messages.mapathonSummaryZeroFeatures} />
         </p>
       )}
     </div>
@@ -60,92 +61,94 @@ export const MapathonSummaryResults = ({ data }) => {
     </div>
   );
 };
-const MAPATHON_DETAILED_COLUMN_HEADINGS= [
-    { title: "Mapper" }, 
-    { title: "AddedBuildings" }, 
-    { title: "ModifiedBuildings" }, 
-    { title: "AddedHighways" }, 
-    { title: "MappedTasks" },
-    { title: "ValidatedTasks" },
-    { title: "DataQualityIssues" }
+const MAPATHON_DETAILED_COLUMN_HEADINGS = [
+  { title: "Mapper" },
+  { title: "AddedBuildings" },
+  { title: "ModifiedBuildings" },
+  { title: "AddedHighways" },
+  { title: "MappedTasks" },
+  { title: "ValidatedTasks" },
+  { title: "DataQualityIssues" },
 ];
 
+export const MapathonDetailedResults = ({ data }) => {
+  const { mappedFeatures, contributors } = data;
+  const { formData } = useContext(MapathonContext);
+  const [downloadError, setDownloadError] = useState(null);
 
-export const MapathonDetailedResults = ({data}) => {
-    const { mappedFeatures, contributors } = data;
-    const { formData } = useContext(MapathonContext);
-    const [downloadError, setDownloadError] = useState(null)
-
-    if (mappedFeatures.length > 0 && contributors.length > 0) {
-        return (
-            <>
-            {downloadError && (
-                <Error>
-                    <MapathonErrorMessage
-                        error={downloadError}
-                    />
-                </Error>
-            )}
-            <table className="table-fixed mt-5 mx-auto">
-                <thead>
-                    <tr>
-                        {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
-                            return(
-                                <th key={n} className="w-1/12 text-left font-bold text-xl px-7 py-4">
-                                    <FormattedMessage {...messages[i.title]} />
-                                </th> 
-                            )}
-                        )}
-                    </tr>
-                </thead>
-                <tbody>
-                    {sortUserData(data).map((i) => (
-                        <tr key={i["userId"]}>
-                            <td className="py-2 px-7 text-lg">
-                                <NavLink
-                                to={{ pathname:`https://www.openstreetmap.org/user/${i["username"]}`}}
-                                target="_blank"
-                                className="hover:underline"
-                                >
-                                    {i["username"]}
-                                </NavLink>
-                            </td>
-                            <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
-                            <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
-                            <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
-                            <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
-                            <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
-                            <td className="py-2 px-7 text-lg">
-                                Download &nbsp;
-                                <DownloadFileLink
-                                    username={i["username"]} 
-                                    type={"csv"} 
-                                    startDate={formData.startDate}
-                                    endDate={formData.endDate}
-                                    setDownloadError={setDownloadError}
-                                />
-                                /
-                                <DownloadFileLink
-                                    username={i["username"]}
-                                    type={"json"} 
-                                    startDate={formData.startDate}
-                                    endDate={formData.endDate}
-                                    setDownloadError={setDownloadError}
-                                />
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-            </>
-        )
-    } else {
-        return (
-            <div className="mx-auto text-center w-1/4 p-1 mt-5">
-                <p className="text-lg">
-                    <FormattedMessage {...messages.noDataFound} />
-                </p>
-            </div>
-        );
-    }
+  if (mappedFeatures.length > 0 && contributors.length > 0) {
+    return (
+      <>
+        {downloadError && (
+          <Error>
+            <MapathonErrorMessage error={downloadError} />
+          </Error>
+        )}
+        <table className="table-fixed mt-5 mx-auto">
+          <thead>
+            <tr>
+              {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
+                return (
+                  <th
+                    key={n}
+                    className="w-1/12 text-left font-bold text-xl px-7 py-4"
+                  >
+                    <FormattedMessage {...messages[i.title]} />
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {sortUserData(data).map((i) => (
+              <tr key={i["userId"]}>
+                <td className="py-2 px-7 text-lg">
+                  <NavLink
+                    to={{
+                      pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
+                    }}
+                    target="_blank"
+                    className="hover:underline"
+                  >
+                    {i["username"]}
+                  </NavLink>
+                </td>
+                <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
+                <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
+                <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
+                <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
+                <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
+                <td className="py-2 px-7 text-lg">
+                  Download &nbsp;
+                  <DownloadFileLink
+                    username={i["username"]}
+                    type={"csv"}
+                    startDate={formData.startDate}
+                    endDate={formData.endDate}
+                    setDownloadError={setDownloadError}
+                  />
+                  /
+                  <DownloadFileLink
+                    username={i["username"]}
+                    type={"json"}
+                    startDate={formData.startDate}
+                    endDate={formData.endDate}
+                    setDownloadError={setDownloadError}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+  } else {
+    return (
+      <div className="mx-auto text-center w-1/4 p-1 mt-5">
+        <p className="text-lg">
+          <FormattedMessage {...messages.noDataFound} />
+        </p>
+      </div>
+    );
+  }
 };

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,27 +1,30 @@
-import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
-import { NavLink } from "react-router-dom";
-import { sortUserData } from "../../utils/sortMapathonResultsData";
-import messages from "../messages";
+import React, { useContext, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { NavLink } from 'react-router-dom';
+import { sortUserData } from '../../utils/sortMapathonResultsData';
+import messages from '../messages';
+import { MapathonContext } from "../../context/mapathonContext";
+import { DownloadFileLink } from '../downloadLink';
+import { Error } from '../formResponses';
+import { MapathonErrorMessage } from './mapathonError';
 
 const FeatureList = ({ title, features }) => {
-  return (
-    <div className="w-auto">
-      <h2 className="text-2xl py-2">{title}:</h2>
-      {features && features.length > 0 ? (
-        <ul>
-          {features &&
-            features.map((item, n) => (
-              <li key={n}>
-                <p className="text-xl">
-                  {item.feature}: {item.count}
-                </p>
-              </li>
-            ))}
-        </ul>
-      ) : (
-        <p>
-          <FormattedMessage {...messages.mapathonSummaryZeroFeatures} />
+    return (
+        <div className="w-auto">
+            <h2 className="text-2xl py-2 font-bold">
+                {title}:
+            </h2>
+            {features && features.length > 0 ? (
+                <ul>
+                {features && features.map((item, n) =>
+                    <li key={n}>
+                        <p className="text-xl">{item.feature}: {item.count}</p>  
+                    </li>
+                )}
+            </ul>
+            ): (
+                <p>
+                    <FormattedMessage {...messages.mapathonSummaryZeroFeatures}/>
         </p>
       )}
     </div>
@@ -63,23 +66,32 @@ const MAPATHON_DETAILED_COLUMN_HEADINGS= [
     { title: "ModifiedBuildings" }, 
     { title: "AddedHighways" }, 
     { title: "MappedTasks" },
-    { title: "ValidatedTasks" }
+    { title: "ValidatedTasks" },
+    { title: "DataQualityIssues" }
 ];
 
 
 export const MapathonDetailedResults = ({data}) => {
-    const { mappedFeatures, contributors } = data
+    const { mappedFeatures, contributors } = data;
+    const { formData } = useContext(MapathonContext);
+    const [downloadError, setDownloadError] = useState(null)
+
     if (mappedFeatures.length > 0 && contributors.length > 0) {
         return (
+            <>
+            {downloadError && (
+                <Error>
+                    <MapathonErrorMessage
+                        error={downloadError}
+                    />
+                </Error>
+            )}
             <table className="table-fixed mt-5 mx-auto">
                 <thead>
                     <tr>
                         {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
                             return(
-                                <th 
-                                    key={n} 
-                                    className="w-1/6 text-left font-normal text-xl px-7 py-4"
-                                >
+                                <th key={n} className="w-1/12 text-left font-bold text-xl px-7 py-4">
                                     <FormattedMessage {...messages[i.title]} />
                                 </th> 
                             )}
@@ -103,15 +115,36 @@ export const MapathonDetailedResults = ({data}) => {
                             <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
                             <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
                             <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
+                            <td className="py-2 px-7 text-lg">
+                                Download &nbsp;
+                                <DownloadFileLink
+                                    username={i["username"]} 
+                                    type={"csv"} 
+                                    startDate={formData.startDate}
+                                    endDate={formData.endDate}
+                                    setDownloadError={setDownloadError}
+                                />
+                                /
+                                <DownloadFileLink
+                                    username={i["username"]}
+                                    type={"json"} 
+                                    startDate={formData.startDate}
+                                    endDate={formData.endDate}
+                                    setDownloadError={setDownloadError}
+                                />
+                            </td>
                         </tr>
                     ))}
                 </tbody>
             </table>
+            </>
         )
     } else {
         return (
             <div className="mx-auto text-center w-1/4 p-1 mt-5">
-                <p className="text-lg">No data found!</p>
+                <p className="text-lg">
+                    <FormattedMessage {...messages.noDataFound} />
+                </p>
             </div>
         );
     }

--- a/src/components/mapathon/tests/mapathonReportForms.test.js
+++ b/src/components/mapathon/tests/mapathonReportForms.test.js
@@ -1,19 +1,41 @@
-import React from "react";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
 import { addHours, format } from "date-fns";
-import userEvent from "@testing-library/user-event";
-import { AppProviders } from "../../../utils/testUtils";
-import { MapathonReportForm } from "../mapathonReportForm";
+import { AppProviders } from '../../../utils/testUtils';
+import { MapathonContext } from '../../../context/mapathonContext';
+import { MapathonReportForm } from '../mapathonReportForm';
 
-describe("Mapathon Report Form Component", () => {
-  afterEach(cleanup);
-
-  it("displays all form components", () => {
-    const { getByText, getAllByRole, getByPlaceholderText } = render(
-      <AppProviders>
-        <MapathonReportForm error={null} fetch={jest.fn()} />
+function renderMapathonReportForm(formData, setFormData) {
+  return render(
+    <AppProviders>
+        <MapathonContext.Provider
+          value={{ 
+            formData, 
+            setFormData
+          }}
+        >
+          <MapathonReportForm
+            error={null}
+            fetch={jest.fn()}
+          />
+        </MapathonContext.Provider>
       </AppProviders>
     );
+}
+
+describe("Mapathon Report Form Component", () => {
+  const formData = {
+    startDate: addHours(new Date(), -1),
+    endDate: new Date(),
+    TMProjectIds: "",
+    mapathonHashtags: ""
+  };
+  const setFormData = jest.fn();
+
+  afterEach(cleanup);
+
+  it('displays all form components', () => {
+    const { getByText, getAllByRole, getByPlaceholderText} = renderMapathonReportForm(formData, setFormData);
     // form input titles
     expect(getByText(/Start Date/i)).toBeInTheDocument();
     expect(getByText(/End Date/i)).toBeInTheDocument();
@@ -52,46 +74,4 @@ describe("Mapathon Report Form Component", () => {
     // Submit button
     expect(getByText(/submit your query/i)).toBeInTheDocument();
   });
-
-  it("allows form input changes", async () => {
-    const { getByText, getByRole, getAllByRole, debug } = render(
-      <AppProviders>
-        <MapathonReportForm error={null} fetch={jest.fn()} />
-      </AppProviders>
-    );
-
-    // form input fields
-    const inputs = getAllByRole("textbox");
-    let startDate = inputs[0];
-    let endDate = inputs[1];
-    let projectIds = inputs[2];
-    let hashtags = inputs[3];
-
-    // default form values
-    expect(startDate.value).toContain(
-      format(addHours(new Date(), -1), "d MMMM, yyyy h:mm aa")
-    ); //start date datepicker
-    expect(endDate.value).toContain(format(new Date(), "d MMMM, yyyy h:mm aa")); //end date datepicker
-    expect(projectIds.value).toBe("");
-    expect(hashtags.value).toBe("");
-
-    const submitButton = getByRole("button");
-    // submit empty values for mapathon hashtags and project Ids
-    userEvent.click(submitButton);
-    // await waitFor(() => expect(handleTestSubmit).toHaveBeenCalledTimes(0))
-    // error
-    expect(
-      getByText(/It was not possible to run this query/i)
-    ).toBeInTheDocument();
-
-    // enter values
-    fireEvent.change(projectIds, { target: { value: "111, 1209, 1387" } });
-    expect(projectIds.value).not.toBe("");
-    expect(projectIds.value).toBe("111, 1209, 1387");
-    fireEvent.change(hashtags, { target: { value: "mapchathour" } });
-    expect(hashtags.value).not.toBe("");
-    expect(hashtags.value).toBe("mapchathour");
-    userEvent.click(submitButton);
-    // to do: mock api call and test
-  });
-});
+})

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -69,27 +69,27 @@ export default defineMessages({
         id: 'reports.mapathon.summary.zero.features',
         defaultMessage: "None"
     },
-    mapathonSummaryFormStartDate: {
+    mapathonFormStartDate: {
         id: 'reports.mapathon.summary.form.input.startDate',
         defaultMessage: "Start Date"
     },
-    mapathonSummaryFormEndDate: {
+    mapathonFormEndDate: {
         id: 'reports.mapathon.summary.form.input.endDate',
         defaultMessage: "End Date"
     },
-    mapathonSummaryFormProjectIds: {
+    mapathonFormProjectIds: {
         id: 'reports.mapathon.summary.form.input.projectIds',
         defaultMessage: "Tasking Manager Project IDs"
     },
-    mapathonSummaryFormIdsPlaceholder: {
+    mapathonFormIdsPlaceholder: {
         id: 'reports.mapathon.summary.form.projectIds.placeholder',
         defaultMessage: "Enter the Tasking Manager Project IDs separated by commas"
     },
-    mapathonSummaryFormHashtags: {
+    mapathonFormHashtags: {
         id: 'reports.mapathon.summary.form.input.hashtags',
         defaultMessage: "Mapathon Hashtags"
     },
-    mapathonSummaryFormHashtagsPlaceholder: {
+    mapathonFormHashtagsPlaceholder: {
         id: 'reports.mapathon.summary.form.hashtags.placeholder',
         defaultMessage: "Enter the hashtags separated by commas"
     },
@@ -97,21 +97,25 @@ export default defineMessages({
         id: 'reports.mapathon.summary.form.error.title',
         defaultMessage: "It was not possible to run this query."
     },
-    mapathonSummaryErrorEmptyFields: {
+    mapathonFormErrorEmptyFields: {
         id: 'reports.mapathon.summary.form.error.empty',
         defaultMessage: "Please fill in <b>one</b> of the following to continue"
     },
-    mapathonSummaryErrorInvalidIds: {
+    mapathonFormErrorInvalidIds: {
         id: 'reports.mapathon.summary.form.error.invalidIds',
         defaultMessage: "Please input numerical values for the TM Project IDs."
     },
-    mapathonSummaryErrorInvalidTime: {
+    mapathonFormErrorInvalidTime: {
         id: 'reports.mapathon.summary.form.error.invalidTime',
         defaultMessage: "Time difference should be less than or equal to 24 hours."
     },
     ServerError: {
         id: 'reports.mapathon.summary.form.error.server',
         defaultMessage: "There was a problem with the server - ({error}) while executing this query. Please try again later."
+    },
+    mapathonSubmitForm: {
+        id: 'reports.mapathon.form.submit.button',
+        defaultMessage: "Submit Your Query"
     },
     footerOrganisation: {
         id: 'about.footer.organisation',

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -117,6 +117,30 @@ export default defineMessages({
         id: 'reports.mapathon.form.submit.button',
         defaultMessage: "Submit Your Query"
     },
+    Mapper: {
+        id: 'reports.mapathon.detailed.column.mapper',
+        defaultMessage: 'Mapper'
+    },
+    AddedBuildings: {
+        id: 'reports.mapathon.detailed.column.buildingsAdded',
+        defaultMessage: 'Buildings Added'
+    },
+    ModifiedBuildings: {
+        id: 'reports.mapathon.detailed.column.buildingsModified',
+        defaultMessage: 'Buildings Modified'
+    },
+    AddedHighways: {
+        id: 'reports.mapathon.detailed.column.highwaysAdded',
+        defaultMessage: 'Highways Added'
+    },
+    MappedTasks: {
+        id: 'reports.mapathon.detailed.column.tasksMapped',
+        defaultMessage: 'Tasks Mapped'
+    },
+    ValidatedTasks: {
+        id: 'reports.mapathon.detailed.column.validatedTasks',
+        defaultMessage: 'Tasks Validated'
+    },
     footerOrganisation: {
         id: 'about.footer.organisation',
         defaultMessage: 'This project is under development by {OrganisationLink}.'

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -141,6 +141,14 @@ export default defineMessages({
         id: 'reports.mapathon.detailed.column.validatedTasks',
         defaultMessage: 'Tasks Validated'
     },
+    DataQualityIssues: {
+        id: 'reports.mapathon.detailed.column.dataQualityIssues',
+        defaultMessage: 'Data Quality Issues'
+    },
+    noDataFound: {
+        id: 'reports.mapathon.detailed.results.no.data',
+        defaultMessage: 'No Data Found!'
+    },
     footerOrganisation: {
         id: 'about.footer.organisation',
         defaultMessage: 'This project is under development by {OrganisationLink}.'

--- a/src/context/mapathonContext.js
+++ b/src/context/mapathonContext.js
@@ -1,0 +1,44 @@
+import React, { useReducer, useEffect } from "react";
+import { addHours, parseISO } from "date-fns";
+
+import * as safeStorage from '../utils/safeStorage'
+
+let reducer = (data, newData) => {
+  return { ...data, ...newData };
+};
+
+const initialFormData = {
+  startDate: addHours(new Date(), -1),
+  endDate: new Date(),
+  TMProjectIds: "",
+  mapathonHashtags: ""
+};
+
+const localFormData = JSON.parse(safeStorage.getItem("formData"));
+if (localFormData ) {
+  localFormData.startDate = parseISO(localFormData.startDate)
+  localFormData.endDate = parseISO(localFormData.endDate)
+}
+
+const MapathonContext = React.createContext();
+
+function MapathonContextProvider(props) {
+  const [formData, setFormData] = useReducer(reducer, localFormData || initialFormData);
+
+  useEffect(() => {
+    localStorage.setItem("formData", JSON.stringify(formData));
+  }, [formData]);
+
+  return (
+    <MapathonContext.Provider 
+      value={{ 
+        formData, 
+        setFormData
+      }}
+    >
+      {props.children}
+    </MapathonContext.Provider>
+  );
+}
+
+export { MapathonContext, MapathonContextProvider };

--- a/src/hooks/useDownloadFile.js
+++ b/src/hooks/useDownloadFile.js
@@ -11,6 +11,7 @@ export const useDownloadFile = ({ fetchFile, getFileName }) => {
       const { data } = await fetchFile();
       setFileData(data);
       setFileName(getFileName());
+      setFileError(null);
       ref.current?.click();
     } catch (error) {
       if (error.response.status === 500) {

--- a/src/utils/sortMapathonResultsData.js
+++ b/src/utils/sortMapathonResultsData.js
@@ -11,21 +11,12 @@ const featureActionCount = (array, feature, action, name) => {
 export const sortUserData = (obj) => {
   const arr = [];
   obj.contributors.forEach((i) => {
-    arr.push({
-      ...i,
-      modifiedBuildings: featureActionCount(
-        obj.mappedFeatures,
-        "building",
-        "modify",
-        i["username"]
-      ),
-      createdHighways: featureActionCount(
-        obj.mappedFeatures,
-        "highway",
-        "modify",
-        i["username"]
-      ),
-    });
-  });
+      arr.push({
+          ...i,
+          addedBuildings: featureActionCount(obj.mappedFeatures, "building", "create", i["username"]),
+          modifiedBuildings: featureActionCount(obj.mappedFeatures, "building", "modify", i["username"]),
+          createdHighways: featureActionCount(obj.mappedFeatures, "highway", "create", i["username"])
+      })
+  })
   return arr;
 };

--- a/src/utils/testUtils.js
+++ b/src/utils/testUtils.js
@@ -1,8 +1,8 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { IntlProvider } from "react-intl";
-import { QueryClientProvider, QueryClient } from "react-query";
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import {QueryClientProvider, QueryClient } from 'react-query';
 import { MemoryRouter } from "react-router-dom";
 import store from "../app/store";
 

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -1,60 +1,84 @@
 import React from "react";
-import { useMutation } from 'react-query';
-import { useSelector } from 'react-redux';
+import { useMutation } from "react-query";
+import { useSelector } from "react-redux";
 import { FormattedMessage } from "react-intl";
 import { MapathonReportForm } from "../components/mapathon/mapathonReportForm";
 import {
   getMapathonSummaryReport,
   getMapathonDetailedReport,
 } from "../queries/index";
-import { 
-    MapathonSummaryResults, 
-    MapathonDetailedResults
-} from '../components/mapathon/mapathonResults';
+import {
+  MapathonSummaryResults,
+  MapathonDetailedResults,
+} from "../components/mapathon/mapathonResults";
 import { AuthorisationButton } from "../components/auth";
 import messages from "./messages";
 
 export const MapathonSummaryReport = (props) => {
-    const { mutate, data, isLoading, error } = useMutation(getMapathonSummaryReport);
-    return (
-        <div>
-            <MapathonReportForm
-                error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
-                fetch={mutate}
-                loading={isLoading}
-            />
-            <AuthorisationButton origin={"mapathon"} redirectTo={props.location.pathname}/>
-            {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
-            {data && (<MapathonSummaryResults data={data}/>)}
-        </div>
-    )
+  const { mutate, data, isLoading, error } = useMutation(
+    getMapathonSummaryReport
+  );
+  return (
+    <div>
+      <MapathonReportForm
+        error={
+          error
+            ? error.response.status === 500
+              ? error.response.data
+              : error.response.data.detail[0]["msg"]
+            : ""
+        }
+        fetch={mutate}
+        loading={isLoading}
+      />
+      <AuthorisationButton
+        origin={"mapathon"}
+        redirectTo={props.location.pathname}
+      />
+      {isLoading && (
+        <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
+      )}
+      {data && <MapathonSummaryResults data={data} />}
+    </div>
+  );
 };
 
 export const MapathonDetailedReport = () => {
-    const loggedIn = useSelector((state) => state.auth.loggedIn);
-    const token = useSelector((state) => state.auth.accessToken);
-    
-    const { mutate, data, isLoading, error } = useMutation(getMapathonDetailedReport, {});
-  
-    if (token && loggedIn) {
-        return (
-            <div>
-                <MapathonReportForm
-                    error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
-                    fetch={mutate}
-                    loading={isLoading}
-                />
-                {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
-                {data && (<MapathonDetailedResults data={data}/>)}
-            </div>
-        )
-    } else {
-        return (
-            <div className="text-center"> 
-                <p className="text-red text-xl">
-                    <FormattedMessage {...messages.mapathonDetailedReportUnauthorised}/>
-                </p>
-            </div>
-        )
-    }
+  const loggedIn = useSelector((state) => state.auth.loggedIn);
+  const token = useSelector((state) => state.auth.accessToken);
+
+  const { mutate, data, isLoading, error } = useMutation(
+    getMapathonDetailedReport,
+    {}
+  );
+
+  if (token && loggedIn) {
+    return (
+      <div>
+        <MapathonReportForm
+          error={
+            error
+              ? error.response.status === 500
+                ? error.response.data
+                : error.response.data.detail[0]["msg"]
+              : ""
+          }
+          fetch={mutate}
+          loading={isLoading}
+        />
+        {isLoading && (
+          <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
+        )}
+        {data && <MapathonDetailedResults data={data} />}
+      </div>
+    );
+  } else {
+    return (
+      <div className="text-center">
+        <p className="text-red text-xl">
+          <FormattedMessage {...messages.mapathonDetailedReportUnauthorised} />
+        </p>
+      </div>
+    );
+  }
 };

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -8,7 +8,7 @@ import {
 } from "../queries/index";
 import {
   MapathonSummaryResults,
-  TableResults as MapathonDetailedResults,
+  MapathonDetailedResults,
 } from "../components/mapathon/mapathonResults";
 import { AuthorisationButton } from "../components/auth";
 

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -21,6 +21,7 @@ export const MapathonSummaryReport = (props) => {
             <MapathonReportForm
                 error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
                 fetch={mutate}
+                loading={isLoading}
             />
             <AuthorisationButton origin={"mapathon"} redirectTo={props.location.pathname}/>
             {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
@@ -41,6 +42,7 @@ export const MapathonDetailedReport = () => {
                 <MapathonReportForm
                     error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
                     fetch={mutate}
+                    loading={isLoading}
                 />
                 {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
                 {data && (<MapathonDetailedResults data={data}/>)}

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -1,65 +1,58 @@
 import React from "react";
-import { useMutation } from "react-query";
-import { useSelector } from "react-redux";
+import { useMutation } from 'react-query';
+import { useSelector } from 'react-redux';
+import { FormattedMessage } from "react-intl";
 import { MapathonReportForm } from "../components/mapathon/mapathonReportForm";
 import {
   getMapathonSummaryReport,
   getMapathonDetailedReport,
 } from "../queries/index";
-import {
-  MapathonSummaryResults,
-  MapathonDetailedResults,
-} from "../components/mapathon/mapathonResults";
+import { 
+    MapathonSummaryResults, 
+    MapathonDetailedResults
+} from '../components/mapathon/mapathonResults';
 import { AuthorisationButton } from "../components/auth";
+import messages from "./messages";
 
 export const MapathonSummaryReport = (props) => {
-  const { mutate, data, isLoading, error } = useMutation(
-    getMapathonSummaryReport
-  );
-  return (
-    <div>
-      <MapathonReportForm error={error ? error.message : null} fetch={mutate} />
-      <AuthorisationButton
-        origin={"mapathon"}
-        redirectTo={props.location.pathname}
-      />
-      {isLoading && (
-        <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
-      )}
-      {data && <MapathonSummaryResults data={data} />}
-    </div>
-  );
+    const { mutate, data, isLoading, error } = useMutation(getMapathonSummaryReport);
+    return (
+        <div>
+            <MapathonReportForm
+                error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
+                fetch={mutate}
+            />
+            <AuthorisationButton origin={"mapathon"} redirectTo={props.location.pathname}/>
+            {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
+            {data && (<MapathonSummaryResults data={data}/>)}
+        </div>
+    )
 };
 
 export const MapathonDetailedReport = () => {
-  const loggedIn = useSelector((state) => state.auth.loggedIn);
-  const token = useSelector((state) => state.auth.accessToken);
-
-  const { mutate, data, isLoading, error } = useMutation(
-    getMapathonDetailedReport,
-    {}
-  );
-
-  if (token && loggedIn) {
-    return (
-      <div>
-        <MapathonReportForm
-          error={error ? error.message : null}
-          fetch={mutate}
-        />
-        {isLoading && (
-          <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
-        )}
-        {data && <MapathonDetailedResults data={data} />}
-      </div>
-    );
-  } else {
-    return (
-      <div className="text-center">
-        <p className="text-red text-xl">
-          Please log in first to view detailed report
-        </p>
-      </div>
-    );
-  }
+    const loggedIn = useSelector((state) => state.auth.loggedIn);
+    const token = useSelector((state) => state.auth.accessToken);
+    
+    const { mutate, data, isLoading, error } = useMutation(getMapathonDetailedReport, {});
+  
+    if (token && loggedIn) {
+        return (
+            <div>
+                <MapathonReportForm
+                    error={error ? (error.response.status === 500 ? error.response.data : error.response.data.detail[0]['msg']) : ''}
+                    fetch={mutate}
+                />
+                {isLoading && (<div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>)}
+                {data && (<MapathonDetailedResults data={data}/>)}
+            </div>
+        )
+    } else {
+        return (
+            <div className="text-center"> 
+                <p className="text-red text-xl">
+                    <FormattedMessage {...messages.mapathonDetailedReportUnauthorised}/>
+                </p>
+            </div>
+        )
+    }
 };

--- a/src/views/messages.js
+++ b/src/views/messages.js
@@ -4,87 +4,88 @@ import { defineMessages } from "react-intl";
  * Internationalized messages for use on views.
  */
 export default defineMessages({
-  mapathonReport: {
-    id: "exploreData.mapathonReport",
-    defaultMessage: "Mapathon Reports",
-  },
-  mapathonReportBlurb: {
-    id: "exploreData.mapathonReport.blurb",
-    defaultMessage:
-      "Get to know the impact created through a mapathon in real-time. You can generate a report of all the mapper contributions covering different types of feature count and the time they spent mapping on Tasking Manager.",
-  },
-  userReport: {
-    id: "exploreData.userReport",
-    defaultMessage: "User Reports",
-  },
-  userReportBlurb: {
-    id: "exploreData.userReport.blurb",
-    defaultMessage: "Know how specific mappers have contributed to OSM.",
-  },
-  organisationReport: {
-    id: "exploreData.organisationReport",
-    defaultMessage: "Organisation Reports",
-  },
-  organisationReportBlurb: {
-    id: "exploreData.organisationReport.blurb",
-    defaultMessage: "Organisation Report",
-  },
-  countryReport: {
-    id: "exploreData.countryReport",
-    defaultMessage: "Country Reports",
-  },
-  countryReportBlurb: {
-    id: "exploreData.countryReport.blurb",
-    defaultMessage:
-      "Learn about the growth of OSM features in a country from the beginning of time on a monthly basis.",
-  },
-  projectOverview: {
-    id: "about.galaxy.overview",
-    defaultMessage:
-      "{OSMLink} Galaxy is a project that the HOT Tech Team launched this mid-April (14th April, 2021) to optimise and improve availability and accessibility of OSM Data outputs for different user groups within the ecosystem. Through this project, we strive to address all the OSM data needs under one umbrella and ensure OSM data is available, accessible and ready to use for all kinds of users. We are trying to solve the high dependency on different data sources and uncontrolled platforms while focusing on fast queries and process optimisation by accessing data from HOT administered and controlled environment.",
-  },
-  resourcesHeading: {
-    id: "about.galaxy.resources.heading",
-    defaultMessage: "Get started on this project with these documents",
-  },
-  galaxySlideDeck: {
-    id: "about.galaxy.resources.slideDeck",
-    defaultMessage: "OSM Galaxy Slide Deck",
-  },
-  galaxyUserStories: {
-    id: "about.galaxy.resources.slideDeck",
-    defaultMessage: "User Stories for Galaxy",
-  },
-  osmStatsDoc: {
-    id: "about.galaxy.resources.slideDeck",
-    defaultMessage: "OSM Statistics API Access",
-  },
-  underpassOverview: {
-    id: "about.galaxy.resources.underpass.overview",
-    defaultMessage: "Underpass Technical Overview",
-  },
-  wireframesAccess: {
-    id: "about.galaxy.resources.wireframes",
-    defaultMessage: "Website Wireframes on Figma",
-  },
-  apiRequirements: {
-    id: "about.galaxy.resources.api.requirements",
-    defaultMessage: "API Functional Requirements",
-  },
-  websiteAcceptanceCriteria: {
-    id: "about.galaxy.resources.website.documentation",
-    defaultMessage: "Website Requirements",
-  },
-  workingGroupRegistration: {
-    id: "about.galaxy.resources.workingGroup.registration",
-    defaultMessage: "Register your interest for Working Group",
-  },
-  osmStatsDownload: {
-    id: "about.galaxy.resources.osmStatsDownload",
-    defaultMessage: "OSM statistics Data Download",
-  },
-  galaxyFAQ: {
-    id: "about.galaxy.resources.faq",
-    defaultMessage: "FAQ on Galaxy (To be Updated)",
-  },
+    mapathonReport: {
+        id: 'exploreData.mapathonReport',
+        defaultMessage: "Mapathon Reports"
+    },
+    mapathonReportBlurb: {
+        id: 'exploreData.mapathonReport.blurb',
+        defaultMessage: "Get to know the impact created through a mapathon in real-time. You can generate a report of all the mapper contributions covering different types of feature count and the time they spent mapping on Tasking Manager."
+    },
+    userReport: {
+        id: 'exploreData.userReport',
+        defaultMessage: "User Reports"
+    },
+    userReportBlurb: {
+        id: 'exploreData.userReport.blurb',
+        defaultMessage: "Know how specific mappers have contributed to OSM."
+    },
+    organisationReport: {
+        id: 'exploreData.organisationReport',
+        defaultMessage: "Organisation Reports"
+    },
+    organisationReportBlurb: {
+        id: 'exploreData.organisationReport.blurb',
+        defaultMessage: "Organisation Report"
+    },
+    countryReport: {
+        id: 'exploreData.countryReport',
+        defaultMessage: "Country Reports"
+    },
+    countryReportBlurb: {
+        id: 'exploreData.countryReport.blurb',
+        defaultMessage: "Learn about the growth of OSM features in a country from the beginning of time on a monthly basis."
+    },
+    projectOverview: {
+      id: 'about.galaxy.overview',
+      defaultMessage: "{OSMLink} Galaxy is a project that the HOT Tech Team launched this mid-April (14th April, 2021) to optimise and improve availability and accessibility of OSM Data outputs for different user groups within the ecosystem. Through this project, we strive to address all the OSM data needs under one umbrella and ensure OSM data is available, accessible and ready to use for all kinds of users. We are trying to solve the high dependency on different data sources and uncontrolled platforms while focusing on fast queries and process optimisation by accessing data from HOT administered and controlled environment."
+    },
+    resourcesHeading: {
+      id: 'about.galaxy.resources.heading',
+      defaultMessage: "Get started on this project with these documents"
+    },
+    galaxySlideDeck: {
+      id: 'about.galaxy.resources.slideDeck',
+      defaultMessage: "OSM Galaxy Slide Deck"
+    },
+    galaxyUserStories: {
+      id: 'about.galaxy.resources.slideDeck',
+      defaultMessage: "User Stories for Galaxy"
+    },
+    osmStatsDoc: {
+      id: 'about.galaxy.resources.slideDeck',
+      defaultMessage: "OSM Statistics API Access"
+    },
+    underpassOverview: {
+      id: 'about.galaxy.resources.underpass.overview',
+      defaultMessage: "Underpass Technical Overview"
+    },
+    wireframesAccess: {
+      id: 'about.galaxy.resources.wireframes',
+      defaultMessage: "Website Wireframes on Figma"
+    },
+    apiRequirements: {
+      id: 'about.galaxy.resources.api.requirements',
+      defaultMessage: "API Functional Requirements"
+    },
+    websiteAcceptanceCriteria: {
+      id: 'about.galaxy.resources.website.documentation',
+      defaultMessage: "Website Requirements"
+    },
+    workingGroupRegistration: {
+      id: 'about.galaxy.resources.workingGroup.registration',
+      defaultMessage: "Register your interest for Working Group"
+    },
+    osmStatsDownload: {
+      id: 'about.galaxy.resources.osmStatsDownload',
+      defaultMessage: "OSM statistics Data Download"
+    },
+    galaxyFAQ: {
+      id: 'about.galaxy.resources.faq',
+      defaultMessage: "FAQ on Galaxy (To be Updated)"
+    },
+    mapathonDetailedReportUnauthorised: {
+      id: 'mapathon.detailed.report.warning',
+      defaultMessage: 'Please log in first to view detailed report.'
+    }
 });


### PR DESCRIPTION
Tasks:

- [x] Persist data with Context and local storage instead of Redux for the mapathon pages. (Resolve #29)
- [x] Fix stats displayed on mapathon detailed report. (Resolve #28)
- [x] Add data quality reports for the detailed report page
- [x] Display `highway count` column label instead of `km` in detailed report table results. (Resolve #28)
- [x] tests