### PR TITLE
Modified the DB download per Jorge's fix

### DIFF
--- a/src/views/About.js
+++ b/src/views/About.js
@@ -113,7 +113,7 @@ export function About() {
                                 </li>
                                 <li className="document-link">
                                     <a 
-                                    href="https://osm-stats.hotosm.org/data/download/osmstats"
+                                    href="https://osm-stats.hotosm.org/data/download/galaxy"
                                     target="_blank"
                                     rel="noreferrer"
                                     >


### PR DESCRIPTION
DB file download link on Galaxy page was not working after the DB rename - So @JorgeMartinezG fixed that and related OSM client issue. Pushing this fix for the latest download link.

cc @d-rita 