### PR TITLE
Indicate user's timezone on forms with date input

### DIFF
--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -7,10 +7,11 @@ import "react-datepicker/dist/react-datepicker.css";
 import { SubmitButton } from "../button";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
-import messages from "../messages";
 import { validateMapathonFormData } from "../../utils/validationUtils";
 import { MapathonContext } from "../../context/mapathonContext";
 import { setLoading, setTriggerSubmit } from "../../features/form/formSlice";
+import { getTimeZone } from "../../utils/timeUtils";
+import messages from "../messages";
 
 export const MapathonReportForm = ({ fetch, error, loading }) => {
   const intl = useIntl();
@@ -71,6 +72,9 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
               <label>
                 <span className="text-red">* </span>
                 <FormattedMessage {...messages.mapathonFormStartDate} />:
+                <span className="text-lg">
+                  &nbsp;({getTimeZone(new Date())})
+                </span>
               </label>
               <DatePicker
                 selected={formData.startDate}
@@ -91,6 +95,9 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
               <label>
                 <span className="text-red">* </span>
                 <FormattedMessage {...messages.mapathonFormEndDate} />:
+                <span className="text-lg">
+                  &nbsp;({getTimeZone(new Date())})
+                </span>
               </label>
               <DatePicker
                 selected={formData.endDate}

--- a/src/components/userGroup/userGroupForm.js
+++ b/src/components/userGroup/userGroupForm.js
@@ -6,6 +6,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import { SubmitButton } from "../button";
 import { Error } from "../formResponses";
 import { UserGroupErrorMessage } from "./userGroupError";
+import { getTimeZone } from "../../utils/timeUtils";
 import messages from "./messages";
 
 export const UserGroupReportForm = ({
@@ -48,6 +49,9 @@ export const UserGroupReportForm = ({
               <label>
                 <span className="text-red">* </span>
                 <FormattedMessage {...messages.StartDate} />:
+                <span className="text-lg">
+                  &nbsp;({getTimeZone(new Date())})
+                </span>
               </label>
               <DatePicker
                 selected={formData.startDate}
@@ -68,6 +72,9 @@ export const UserGroupReportForm = ({
               <label>
                 <span className="text-red">* </span>
                 <FormattedMessage {...messages.EndDate} />:
+                <span className="text-lg">
+                  &nbsp;({getTimeZone(new Date())})
+                </span>
               </label>
               <DatePicker
                 selected={formData.endDate}

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -1,0 +1,10 @@
+export const getTimeZone = (date) => {
+  const offset = date.getTimezoneOffset();
+  const absoluteValue = Math.abs(offset);
+
+  let symbol = offset < 0 ? "+" : "-";
+  let hours = ("00" + Math.floor(absoluteValue / 60)).slice(-2);
+  let minutes = ("00" + (absoluteValue % 60)).slice(-2);
+
+  return `UTC${symbol}${hours}:${minutes}`;
+};


### PR DESCRIPTION
**What does this PR do?** 

This PR indicates a user's timezone next to the `start date` and `end date` labels on the User Group Report and the Mapathon pages' respective form inputs in the UTC+/- format. 

**Screenshot:**

![date tz](https://user-images.githubusercontent.com/31903212/160937862-81a6d38e-9a45-40f9-8c00-0dfabe20a2e4.png)

**Related Issues:**
- Fixes #74 