### PR TITLE
Sortable table columns via mapathon and user report pages.  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-redux": "^7.2.5",
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
+        "react-table": "^7.7.0",
         "web-vitals": "^1.0.1",
         "webfontloader": "^1.6.28"
       },
@@ -2440,7 +2441,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -5703,7 +5703,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7931,8 +7930,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -11950,7 +11948,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -13267,7 +13264,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -18638,7 +18634,6 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
-        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -18747,6 +18742,18 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-table": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
+      "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17.0.0-0"
       }
     },
     "node_modules/read-cache": {
@@ -22465,10 +22472,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -22558,7 +22563,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -22987,7 +22991,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -23520,9 +23523,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -24008,9 +24008,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -38536,6 +38533,12 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
+    },
+    "react-table": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
+      "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-redux": "^7.2.5",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-table": "^7.7.0",
     "web-vitals": "^1.0.1",
     "webfontloader": "^1.6.28"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import {
 } from "./views/MapathonReports";
 import { UserGroupReport } from "./views/UserGroupReport";
 import { MapathonContextProvider } from "./context/mapathonContext";
+import { UserGroupContextProvider } from "./context/userGroupContext";
 
 function App() {
   return (
@@ -26,9 +27,11 @@ function App() {
             <Route path="/authorised" component={LoginCallback} />
             <Route path="/about" component={About} />
             <Route path="/explore" component={Reports} />
-            <ProtectedRoute path={"/user-report"}>
-              <UserGroupReport />
-            </ProtectedRoute>
+            <UserGroupContextProvider>
+              <ProtectedRoute path={"/user-report"}>
+                <UserGroupReport />
+              </ProtectedRoute>
+            </UserGroupContextProvider>
           </Switch>
           <Switch>
             <MapathonContextProvider>

--- a/src/assets/svgIcons/index.js
+++ b/src/assets/svgIcons/index.js
@@ -1,1 +1,2 @@
 export { BanIcon } from "./ban";
+export { SortIcon, SortDownIcon, SortUpIcon } from "./sortIcons";

--- a/src/assets/svgIcons/sortIcons.js
+++ b/src/assets/svgIcons/sortIcons.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+// Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com
+// License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+// Copyright 2022 Fonticons, Inc.
+
+export class SortIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        {...this.props}
+      >
+        <path
+          fill="currentColor"
+          d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224zM292.3 288H27.66c-24.6 0-36.89 29.77-19.54 47.12l132.5 136.8C145.9 477.3 152.1 480 160 480c7.053 0 14.12-2.703 19.53-8.109l132.3-136.8C329.2 317.8 316.9 288 292.3 288z"
+        />
+      </svg>
+    );
+  }
+}
+
+export class SortUpIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        {...this.props}
+      >
+        <path
+          fill="currentColor"
+          d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224z"
+        />
+      </svg>
+    );
+  }
+}
+
+export class SortDownIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        {...this.props}
+      >
+        <path
+          fill="currentColor"
+          d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+        />
+      </svg>
+    );
+  }
+}

--- a/src/components/download.js
+++ b/src/components/download.js
@@ -1,8 +1,10 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
+import React, { useContext } from "react";
 import axios from "axios";
-import React from "react";
 import { API_URL } from "../config";
 import { useDownloadFile } from "../hooks/useDownloadFile";
+import { MapathonContext } from "../context/mapathonContext";
+import { UserGroupContext } from "../context/userGroupContext";
 
 export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
   const fetchFile = () => {
@@ -45,6 +47,30 @@ export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
       >
         {type === "csv" ? "CSV" : "JSON"}
       </button>
+    </>
+  );
+};
+
+export const DownloadDataCell = ({ value, source }) => {
+  const { formData } = useContext(
+    source === "mapathon" ? MapathonContext : UserGroupContext
+  );
+  return (
+    <>
+      Download &nbsp;
+      <DownloadFileLink
+        username={value}
+        type={"csv"}
+        startDate={formData.startDate}
+        endDate={formData.endDate}
+      />
+      /
+      <DownloadFileLink
+        username={value}
+        type={"geojson"}
+        startDate={formData.startDate}
+        endDate={formData.endDate}
+      />
     </>
   );
 };

--- a/src/components/downloadLink.js
+++ b/src/components/downloadLink.js
@@ -2,23 +2,19 @@
 import axios from "axios";
 import React from "react";
 import { useEffect } from "react";
+import { useDispatch } from "react-redux";
 import { API_URL } from "../config";
+import { setDownloadError } from "../features/form/formSlice";
 import { useDownloadFile } from "../hooks/useDownloadFile";
 
-export const DownloadFileLink = ({
-  username,
-  type,
-  startDate,
-  endDate,
-  setDownloadError,
-}) => {
+export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
   const fetchFile = () => {
     const body = {
       fromTimestamp: startDate,
       toTimestamp: endDate,
       osmUsernames: [username],
       issueTypes: ["badgeom"],
-      outputType: type === "json" ? "geojson" : type,
+      outputType: type,
     };
     return axios.post(`${API_URL}/data-quality/user-reports`, body);
   };
@@ -27,14 +23,10 @@ export const DownloadFileLink = ({
     return `${username}.${type}`;
   };
 
-  const { ref, fileData, download, fileName, fileError } = useDownloadFile({
+  const { ref, fileData, download, fileName } = useDownloadFile({
     fetchFile,
     getFileName,
   });
-
-  useEffect(() => {
-    setDownloadError(fileError);
-  }, [fileError, setDownloadError]);
 
   return (
     <>
@@ -42,7 +34,7 @@ export const DownloadFileLink = ({
         href={
           type === "csv"
             ? `data:text/csv;charset=utf-8,${escape(fileData)}`
-            : "data:text/json;charset=utf-8," +
+            : "data:application/geo+json;charset=utf-8," +
               encodeURIComponent(JSON.stringify(fileData))
         }
         download={fileName}

--- a/src/components/downloadLink.js
+++ b/src/components/downloadLink.js
@@ -1,10 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 import axios from "axios";
 import React from "react";
-import { useEffect } from "react";
-import { useDispatch } from "react-redux";
 import { API_URL } from "../config";
-import { setDownloadError } from "../features/form/formSlice";
 import { useDownloadFile } from "../hooks/useDownloadFile";
 
 export const DownloadFileLink = ({ username, type, startDate, endDate }) => {

--- a/src/components/mapathon/constants.js
+++ b/src/components/mapathon/constants.js
@@ -1,9 +1,12 @@
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import messages from "../messages";
 import { DownloadDataCell } from "./mapathonResults";
 
 export const MapathonDetailedTableHeaders = [
-  { accessor: "username", Header: <FormattedMessage {...messages.Mapper} /> },
+  {
+    accessor: "username",
+    Header: <FormattedMessage {...messages.Mapper} />,
+  },
   {
     accessor: "addedBuildings",
     Header: <FormattedMessage {...messages.AddedBuildings} />,
@@ -27,15 +30,19 @@ export const MapathonDetailedTableHeaders = [
   {
     accessor: "timeSpentMapping",
     Header: <FormattedMessage {...messages.TimeSpentMapping} />,
+    Cell: ({ cell: { value } }) => value.toLocaleString(),
   },
   {
     accessor: "timeSpentValidating",
     Header: <FormattedMessage {...messages.TimeSpentValidating} />,
+    Cell: ({ cell: { value } }) => value.toLocaleString(),
   },
   {
     id: "userId",
     accessor: "username",
     Header: <FormattedMessage {...messages.DataQualityIssues} />,
     Cell: ({ cell: { value } }) => <DownloadDataCell value={value} />,
+    disableSortBy: true,
+    defaultCanSort: false,
   },
 ];

--- a/src/components/mapathon/constants.js
+++ b/src/components/mapathon/constants.js
@@ -1,7 +1,7 @@
 import { NavLink } from "react-router-dom";
 import { FormattedMessage } from "react-intl";
 import messages from "../messages";
-import { DownloadDataCell } from "./mapathonResults";
+import { DownloadDataCell } from "../download";
 
 export const MapathonDetailedTableHeaders = [
   {
@@ -55,7 +55,9 @@ export const MapathonDetailedTableHeaders = [
     id: "userId",
     accessor: "username",
     Header: <FormattedMessage {...messages.DataQualityIssues} />,
-    Cell: ({ cell: { value } }) => <DownloadDataCell value={value} />,
+    Cell: ({ cell: { value } }) => (
+      <DownloadDataCell value={value} source="mapathon" />
+    ),
     disableSortBy: true,
     defaultCanSort: false,
   },

--- a/src/components/mapathon/constants.js
+++ b/src/components/mapathon/constants.js
@@ -1,0 +1,41 @@
+import { FormattedMessage, useIntl } from "react-intl";
+import messages from "../messages";
+import { DownloadDataCell } from "./mapathonResults";
+
+export const MapathonDetailedTableHeaders = [
+  { accessor: "username", Header: <FormattedMessage {...messages.Mapper} /> },
+  {
+    accessor: "addedBuildings",
+    Header: <FormattedMessage {...messages.AddedBuildings} />,
+  },
+  {
+    accessor: "modifiedBuildings",
+    Header: <FormattedMessage {...messages.ModifiedBuildings} />,
+  },
+  {
+    accessor: "createdHighways",
+    Header: <FormattedMessage {...messages.AddedHighways} />,
+  },
+  {
+    accessor: "mappedTasks",
+    Header: <FormattedMessage {...messages.MappedTasks} />,
+  },
+  {
+    accessor: "validatedTasks",
+    Header: <FormattedMessage {...messages.ValidatedTasks} />,
+  },
+  {
+    accessor: "timeSpentMapping",
+    Header: <FormattedMessage {...messages.TimeSpentMapping} />,
+  },
+  {
+    accessor: "timeSpentValidating",
+    Header: <FormattedMessage {...messages.TimeSpentValidating} />,
+  },
+  {
+    id: "userId",
+    accessor: "username",
+    Header: <FormattedMessage {...messages.DataQualityIssues} />,
+    Cell: ({ cell: { value } }) => <DownloadDataCell value={value} />,
+  },
+];

--- a/src/components/mapathon/constants.js
+++ b/src/components/mapathon/constants.js
@@ -1,3 +1,4 @@
+import { NavLink } from "react-router-dom";
 import { FormattedMessage } from "react-intl";
 import messages from "../messages";
 import { DownloadDataCell } from "./mapathonResults";
@@ -6,6 +7,19 @@ export const MapathonDetailedTableHeaders = [
   {
     accessor: "username",
     Header: <FormattedMessage {...messages.Mapper} />,
+    Cell: ({ cell: { value } }) => {
+      return (
+        <NavLink
+          to={{
+            pathname: `https://www.openstreetmap.org/user/${value}`,
+          }}
+          target="_blank"
+          className="hover:underline"
+        >
+          {value}
+        </NavLink>
+      );
+    },
   },
   {
     accessor: "addedBuildings",

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,15 +1,13 @@
 import React, { useContext } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-// import { NavLink } from "react-router-dom";
-import { useTable } from "react-table";
-// import { aggregateUserData } from "../../utils/mapathonDataUtils";
+import { useTable, useSortBy } from "react-table";
 import messages from "../messages";
 import { MapathonContext } from "../../context/mapathonContext";
 import { DownloadFileLink } from "../downloadLink";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
-import { MapathonDetailedTableHeaders } from "./constants";
 import { useSelector } from "react-redux";
+import { SortDownIcon, SortIcon, SortUpIcon } from "../../assets/svgIcons";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -64,108 +62,9 @@ export const MapathonSummaryResults = ({ data }) => {
     </div>
   );
 };
-const MAPATHON_DETAILED_COLUMN_HEADINGS = [
-  { title: "Mapper" },
-  { title: "AddedBuildings" },
-  { title: "ModifiedBuildings" },
-  { title: "AddedHighways" },
-  { title: "MappedTasks" },
-  { title: "ValidatedTasks" },
-  { title: "TimeSpentMapping" },
-  { title: "TimeSpentValidating" },
-  { title: "DataQualityIssues" },
-];
-
-// export const MapathonDetailedResults = ({ data }) => {
-//   console.log(aggregateUserData(data));
-//   const { mappedFeatures, contributors } = data;
-//   const { formData } = useContext(MapathonContext);
-//   const [downloadError, setDownloadError] = useState(null);
-
-//   if (mappedFeatures.length > 0 && contributors.length > 0) {
-//     return (
-//       <>
-//         {downloadError && (
-//           <Error>
-//             <MapathonErrorMessage error={downloadError} />
-//           </Error>
-//         )}
-//         <table className="table-fixed mt-5 mx-auto">
-//           <thead>
-//             <tr>
-//               {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
-//                 return (
-//                   <th
-//                     key={n}
-//                     className="w-1/12 text-left font-bold text-xl px-7 py-4"
-//                   >
-//                     <FormattedMessage {...messages[i.title]} />
-//                   </th>
-//                 );
-//               })}
-//             </tr>
-//           </thead>
-//           <tbody>
-//             {aggregateUserData(data).map((i) => (
-//               <tr key={i["userId"]}>
-//                 <td className="py-2 px-7 text-lg">
-//                   <NavLink
-//                     to={{
-//                       pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
-//                     }}
-//                     target="_blank"
-//                     className="hover:underline"
-//                   >
-//                     {i["username"]}
-//                   </NavLink>
-//                 </td>
-//                 <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
-//                 <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
-//                 <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
-//                 <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
-//                 <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
-//                 <td className="py-2 px-7 text-lg">{i["timeSpentMapping"]}</td>
-//                 <td className="py-2 px-7 text-lg">
-//                   {i["timeSpentValidating"]}
-//                 </td>
-//                 <td className="py-2 px-7 text-lg">
-//                   Download &nbsp;
-//                   <DownloadFileLink
-//                     username={i["username"]}
-//                     type={"csv"}
-//                     startDate={formData.startDate}
-//                     endDate={formData.endDate}
-//                     setDownloadError={setDownloadError}
-//                   />
-//                   /
-//                   <DownloadFileLink
-//                     username={i["username"]}
-//                     type={"json"}
-//                     startDate={formData.startDate}
-//                     endDate={formData.endDate}
-//                     setDownloadError={setDownloadError}
-//                   />
-//                 </td>
-//               </tr>
-//             ))}
-//           </tbody>
-//         </table>
-//       </>
-//     );
-//   } else {
-//     return (
-//       <div className="mx-auto text-center w-1/4 p-1 mt-5">
-//         <p className="text-lg">
-//           <FormattedMessage {...messages.noDataFound} />
-//         </p>
-//       </div>
-//     );
-//   }
-// };
 
 export const DownloadDataCell = ({ value }) => {
   const { formData } = useContext(MapathonContext);
-  // const [downloadError, setDownloadError] = useState(null);
 
   return (
     <>
@@ -175,7 +74,6 @@ export const DownloadDataCell = ({ value }) => {
         type={"csv"}
         startDate={formData.startDate}
         endDate={formData.endDate}
-        // setDownloadError={setDownloadError}
       />
       /
       <DownloadFileLink
@@ -183,19 +81,21 @@ export const DownloadDataCell = ({ value }) => {
         type={"geojson"}
         startDate={formData.startDate}
         endDate={formData.endDate}
-        // setDownloadError={setDownloadError}
       />
     </>
   );
 };
 
-export function Table({ columns, data }) {
+export function MapathonDetailedResultsTable({ columns, data }) {
   // Use the state and functions returned from useTable to build your UI
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    useTable({
-      columns,
-      data,
-    });
+    useTable(
+      {
+        columns,
+        data,
+      },
+      useSortBy
+    );
 
   const downloadError = useSelector((state) => state.mapathon.downloadError);
 
@@ -208,41 +108,63 @@ export function Table({ columns, data }) {
             <MapathonErrorMessage error={downloadError} />
           </Error>
         )}
-        <table {...getTableProps()}>
-          <thead>
-            {headerGroups.map((headerGroup) => (
-              <tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => (
-                  <th
-                    className="w-1/12 text-left font-bold text-xl px-7 py-4"
-                    {...column.getHeaderProps()}
-                  >
-                    {column.render("Header")}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody {...getTableBodyProps()}>
-            {rows.map((row, i) => {
-              prepareRow(row);
-              return (
-                <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => {
+        <div className="flex flex-col">
+          <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">
+              <div className="overflow-x-auto"></div>
+              <table {...getTableProps()} className="min-w-full">
+                <thead className="border-b">
+                  {headerGroups.map((headerGroup) => (
+                    <tr {...headerGroup.getHeaderGroupProps()}>
+                      {headerGroup.headers.map((column) => (
+                        <th
+                          scope="col"
+                          className="text-xl font-semibold px-6 py-4 text-left"
+                          {...column.getHeaderProps(
+                            column.getSortByToggleProps()
+                          )}
+                        >
+                          <span className="inline ">
+                            {column.render("Header")} &nbsp;
+                            {column.canSort &&
+                              (column.isSorted ? (
+                                column.isSortedDesc ? (
+                                  <SortDownIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                ) : (
+                                  <SortUpIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                )
+                              ) : (
+                                <SortIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                              ))}
+                          </span>
+                        </th>
+                      ))}
+                    </tr>
+                  ))}
+                </thead>
+                <tbody {...getTableBodyProps()}>
+                  {rows.map((row, i) => {
+                    prepareRow(row);
                     return (
-                      <td
-                        className="py-2 px-7 text-lg"
-                        {...cell.getCellProps()}
-                      >
-                        {cell.render("Cell")}
-                      </td>
+                      <tr {...row.getRowProps()} className="border-b">
+                        {row.cells.map((cell) => {
+                          return (
+                            <td
+                              className="text-lg font-light px-6 py-4 whitespace-nowrap"
+                              {...cell.getCellProps()}
+                            >
+                              {cell.render("Cell")}
+                            </td>
+                          );
+                        })}
+                      </tr>
                     );
                   })}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </>
     );
   } else {
@@ -255,91 +177,3 @@ export function Table({ columns, data }) {
     );
   }
 }
-
-// export const TableResults = ({ data }) => {
-//     const { mappedFeatures, contributors } = data;
-//     const { formData } = useContext(MapathonContext);
-//     const [downloadError, setDownloadError] = useState(null);
-
-//     console.log(aggregateUserData(data));
-
-//     if (mappedFeatures.length > 0 && contributors.length > 0) {
-//       return (
-//         <>
-//           {downloadError && (
-//             <Error>
-//               <MapathonErrorMessage error={downloadError} />
-//             </Error>
-//           )}
-//           <table className="table-fixed mt-5 mx-auto">
-//             <thead>
-//               <tr>
-//                 {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
-//                   return (
-//                     <th
-//                       key={n}
-//                       className="w-1/12 text-left font-bold text-xl px-7 py-4"
-//                     >
-//                       <FormattedMessage {...messages[i.title]} />
-//                     </th>
-//                   );
-//                 })}
-//               </tr>
-//             </thead>
-//             <tbody>
-//               {aggregateUserData(data).map((i) => (
-//                 <tr key={i["userId"]}>
-//                   <td className="py-2 px-7 text-lg">
-//                     <NavLink
-//                       to={{
-//                         pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
-//                       }}
-//                       target="_blank"
-//                       className="hover:underline"
-//                     >
-//                       {i["username"]}
-//                     </NavLink>
-//                   </td>
-//                   <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
-//                   <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
-//                   <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
-//                   <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
-//                   <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
-//                   <td className="py-2 px-7 text-lg">{i["timeSpentMapping"]}</td>
-//                   <td className="py-2 px-7 text-lg">
-//                     {i["timeSpentValidating"]}
-//                   </td>
-//                   <td className="py-2 px-7 text-lg">
-//                     Download &nbsp;
-//                     <DownloadFileLink
-//                       username={i["username"]}
-//                       type={"csv"}
-//                       startDate={formData.startDate}
-//                       endDate={formData.endDate}
-//                       setDownloadError={setDownloadError}
-//                     />
-//                     /
-//                     <DownloadFileLink
-//                       username={i["username"]}
-//                       type={"json"}
-//                       startDate={formData.startDate}
-//                       endDate={formData.endDate}
-//                       setDownloadError={setDownloadError}
-//                     />
-//                   </td>
-//                 </tr>
-//               ))}
-//             </tbody>
-//         </table>
-//       </>
-//     );
-//   } else {
-//     return (
-//       <div className="mx-auto text-center w-1/4 p-1 mt-5">
-//         <p className="text-lg">
-//           <FormattedMessage {...messages.noDataFound} />
-//         </p>
-//       </div>
-//     );
-//   }
-// };

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,12 +1,15 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { NavLink } from "react-router-dom";
-import { aggregateUserData } from "../../utils/mapathonDataUtils";
+// import { NavLink } from "react-router-dom";
+import { useTable } from "react-table";
+// import { aggregateUserData } from "../../utils/mapathonDataUtils";
 import messages from "../messages";
 import { MapathonContext } from "../../context/mapathonContext";
 import { DownloadFileLink } from "../downloadLink";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
+import { MapathonDetailedTableHeaders } from "./constants";
+import { useSelector } from "react-redux";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -73,12 +76,131 @@ const MAPATHON_DETAILED_COLUMN_HEADINGS = [
   { title: "DataQualityIssues" },
 ];
 
-export const MapathonDetailedResults = ({ data }) => {
-  const { mappedFeatures, contributors } = data;
-  const { formData } = useContext(MapathonContext);
-  const [downloadError, setDownloadError] = useState(null);
+// export const MapathonDetailedResults = ({ data }) => {
+//   console.log(aggregateUserData(data));
+//   const { mappedFeatures, contributors } = data;
+//   const { formData } = useContext(MapathonContext);
+//   const [downloadError, setDownloadError] = useState(null);
 
-  if (mappedFeatures.length > 0 && contributors.length > 0) {
+//   if (mappedFeatures.length > 0 && contributors.length > 0) {
+//     return (
+//       <>
+//         {downloadError && (
+//           <Error>
+//             <MapathonErrorMessage error={downloadError} />
+//           </Error>
+//         )}
+//         <table className="table-fixed mt-5 mx-auto">
+//           <thead>
+//             <tr>
+//               {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
+//                 return (
+//                   <th
+//                     key={n}
+//                     className="w-1/12 text-left font-bold text-xl px-7 py-4"
+//                   >
+//                     <FormattedMessage {...messages[i.title]} />
+//                   </th>
+//                 );
+//               })}
+//             </tr>
+//           </thead>
+//           <tbody>
+//             {aggregateUserData(data).map((i) => (
+//               <tr key={i["userId"]}>
+//                 <td className="py-2 px-7 text-lg">
+//                   <NavLink
+//                     to={{
+//                       pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
+//                     }}
+//                     target="_blank"
+//                     className="hover:underline"
+//                   >
+//                     {i["username"]}
+//                   </NavLink>
+//                 </td>
+//                 <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
+//                 <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
+//                 <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
+//                 <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
+//                 <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
+//                 <td className="py-2 px-7 text-lg">{i["timeSpentMapping"]}</td>
+//                 <td className="py-2 px-7 text-lg">
+//                   {i["timeSpentValidating"]}
+//                 </td>
+//                 <td className="py-2 px-7 text-lg">
+//                   Download &nbsp;
+//                   <DownloadFileLink
+//                     username={i["username"]}
+//                     type={"csv"}
+//                     startDate={formData.startDate}
+//                     endDate={formData.endDate}
+//                     setDownloadError={setDownloadError}
+//                   />
+//                   /
+//                   <DownloadFileLink
+//                     username={i["username"]}
+//                     type={"json"}
+//                     startDate={formData.startDate}
+//                     endDate={formData.endDate}
+//                     setDownloadError={setDownloadError}
+//                   />
+//                 </td>
+//               </tr>
+//             ))}
+//           </tbody>
+//         </table>
+//       </>
+//     );
+//   } else {
+//     return (
+//       <div className="mx-auto text-center w-1/4 p-1 mt-5">
+//         <p className="text-lg">
+//           <FormattedMessage {...messages.noDataFound} />
+//         </p>
+//       </div>
+//     );
+//   }
+// };
+
+export const DownloadDataCell = ({ value }) => {
+  const { formData } = useContext(MapathonContext);
+  // const [downloadError, setDownloadError] = useState(null);
+
+  return (
+    <>
+      Download &nbsp;
+      <DownloadFileLink
+        username={value}
+        type={"csv"}
+        startDate={formData.startDate}
+        endDate={formData.endDate}
+        // setDownloadError={setDownloadError}
+      />
+      /
+      <DownloadFileLink
+        username={value}
+        type={"geojson"}
+        startDate={formData.startDate}
+        endDate={formData.endDate}
+        // setDownloadError={setDownloadError}
+      />
+    </>
+  );
+};
+
+export function Table({ columns, data }) {
+  // Use the state and functions returned from useTable to build your UI
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable({
+      columns,
+      data,
+    });
+
+  const downloadError = useSelector((state) => state.mapathon.downloadError);
+
+  // Render the UI for your table
+  if (data.length > 0) {
     return (
       <>
         {downloadError && (
@@ -86,64 +208,39 @@ export const MapathonDetailedResults = ({ data }) => {
             <MapathonErrorMessage error={downloadError} />
           </Error>
         )}
-        <table className="table-fixed mt-5 mx-auto">
+        <table {...getTableProps()}>
           <thead>
-            <tr>
-              {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
-                return (
+            {headerGroups.map((headerGroup) => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => (
                   <th
-                    key={n}
                     className="w-1/12 text-left font-bold text-xl px-7 py-4"
+                    {...column.getHeaderProps()}
                   >
-                    <FormattedMessage {...messages[i.title]} />
+                    {column.render("Header")}
                   </th>
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {aggregateUserData(data).map((i) => (
-              <tr key={i["userId"]}>
-                <td className="py-2 px-7 text-lg">
-                  <NavLink
-                    to={{
-                      pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
-                    }}
-                    target="_blank"
-                    className="hover:underline"
-                  >
-                    {i["username"]}
-                  </NavLink>
-                </td>
-                <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
-                <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
-                <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
-                <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
-                <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
-                <td className="py-2 px-7 text-lg">{i["timeSpentMapping"]}</td>
-                <td className="py-2 px-7 text-lg">
-                  {i["timeSpentValidating"]}
-                </td>
-                <td className="py-2 px-7 text-lg">
-                  Download &nbsp;
-                  <DownloadFileLink
-                    username={i["username"]}
-                    type={"csv"}
-                    startDate={formData.startDate}
-                    endDate={formData.endDate}
-                    setDownloadError={setDownloadError}
-                  />
-                  /
-                  <DownloadFileLink
-                    username={i["username"]}
-                    type={"json"}
-                    startDate={formData.startDate}
-                    endDate={formData.endDate}
-                    setDownloadError={setDownloadError}
-                  />
-                </td>
+                ))}
               </tr>
             ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row, i) => {
+              prepareRow(row);
+              return (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell) => {
+                    return (
+                      <td
+                        className="py-2 px-7 text-lg"
+                        {...cell.getCellProps()}
+                      >
+                        {cell.render("Cell")}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </>
@@ -157,4 +254,92 @@ export const MapathonDetailedResults = ({ data }) => {
       </div>
     );
   }
-};
+}
+
+// export const TableResults = ({ data }) => {
+//     const { mappedFeatures, contributors } = data;
+//     const { formData } = useContext(MapathonContext);
+//     const [downloadError, setDownloadError] = useState(null);
+
+//     console.log(aggregateUserData(data));
+
+//     if (mappedFeatures.length > 0 && contributors.length > 0) {
+//       return (
+//         <>
+//           {downloadError && (
+//             <Error>
+//               <MapathonErrorMessage error={downloadError} />
+//             </Error>
+//           )}
+//           <table className="table-fixed mt-5 mx-auto">
+//             <thead>
+//               <tr>
+//                 {MAPATHON_DETAILED_COLUMN_HEADINGS.map((i, n) => {
+//                   return (
+//                     <th
+//                       key={n}
+//                       className="w-1/12 text-left font-bold text-xl px-7 py-4"
+//                     >
+//                       <FormattedMessage {...messages[i.title]} />
+//                     </th>
+//                   );
+//                 })}
+//               </tr>
+//             </thead>
+//             <tbody>
+//               {aggregateUserData(data).map((i) => (
+//                 <tr key={i["userId"]}>
+//                   <td className="py-2 px-7 text-lg">
+//                     <NavLink
+//                       to={{
+//                         pathname: `https://www.openstreetmap.org/user/${i["username"]}`,
+//                       }}
+//                       target="_blank"
+//                       className="hover:underline"
+//                     >
+//                       {i["username"]}
+//                     </NavLink>
+//                   </td>
+//                   <td className="py-2 px-7 text-lg">{i["addedBuildings"]}</td>
+//                   <td className="py-2 px-7 text-lg">{i["modifiedBuildings"]}</td>
+//                   <td className="py-2 px-7 text-lg">{i["createdHighways"]}</td>
+//                   <td className="py-2 px-7 text-lg">{i["mappedTasks"]}</td>
+//                   <td className="py-2 px-7 text-lg">{i["validatedTasks"]}</td>
+//                   <td className="py-2 px-7 text-lg">{i["timeSpentMapping"]}</td>
+//                   <td className="py-2 px-7 text-lg">
+//                     {i["timeSpentValidating"]}
+//                   </td>
+//                   <td className="py-2 px-7 text-lg">
+//                     Download &nbsp;
+//                     <DownloadFileLink
+//                       username={i["username"]}
+//                       type={"csv"}
+//                       startDate={formData.startDate}
+//                       endDate={formData.endDate}
+//                       setDownloadError={setDownloadError}
+//                     />
+//                     /
+//                     <DownloadFileLink
+//                       username={i["username"]}
+//                       type={"json"}
+//                       startDate={formData.startDate}
+//                       endDate={formData.endDate}
+//                       setDownloadError={setDownloadError}
+//                     />
+//                   </td>
+//                 </tr>
+//               ))}
+//             </tbody>
+//         </table>
+//       </>
+//     );
+//   } else {
+//     return (
+//       <div className="mx-auto text-center w-1/4 p-1 mt-5">
+//         <p className="text-lg">
+//           <FormattedMessage {...messages.noDataFound} />
+//         </p>
+//       </div>
+//     );
+//   }
+// };

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,9 +1,7 @@
-import React, { useContext } from "react";
+import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useTable, useSortBy } from "react-table";
 import messages from "../messages";
-import { MapathonContext } from "../../context/mapathonContext";
-import { DownloadFileLink } from "../downloadLink";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
 import { useSelector } from "react-redux";
@@ -60,29 +58,6 @@ export const MapathonSummaryResults = ({ data }) => {
         </div>
       )}
     </div>
-  );
-};
-
-export const DownloadDataCell = ({ value }) => {
-  const { formData } = useContext(MapathonContext);
-
-  return (
-    <>
-      Download &nbsp;
-      <DownloadFileLink
-        username={value}
-        type={"csv"}
-        startDate={formData.startDate}
-        endDate={formData.endDate}
-      />
-      /
-      <DownloadFileLink
-        username={value}
-        type={"geojson"}
-        startDate={formData.startDate}
-        endDate={formData.endDate}
-      />
-    </>
   );
 };
 

--- a/src/components/userGroup/constants.js
+++ b/src/components/userGroup/constants.js
@@ -1,0 +1,48 @@
+import { FormattedMessage } from "react-intl";
+import messages from "./messages";
+import { DownloadDataCell } from "../download";
+
+export const UserGroupColumnHeadings = [
+  {
+    accessor: "userName",
+    Header: <FormattedMessage {...messages.Mapper} />,
+    Cell: ({ cell: { value } }) => {
+      return (
+        <a
+          href={`https://www.openstreetmap.org/user/${value}`}
+          target="_blank"
+          rel="noreferrer"
+          className="hover:underline"
+        >
+          {value}
+        </a>
+      );
+    },
+  },
+  {
+    accessor: "createdBuildings",
+    Header: <FormattedMessage {...messages.CreatedBuildings} />,
+  },
+  {
+    accessor: "modifiedBuildings",
+    Header: <FormattedMessage {...messages.ModifiedBuildings} />,
+  },
+  {
+    accessor: "createdHighways",
+    Header: <FormattedMessage {...messages.CreatedHighways} />,
+  },
+  {
+    accessor: "modifiedHighways",
+    Header: <FormattedMessage {...messages.ModifiedHighways} />,
+  },
+  {
+    id: "userId",
+    accessor: "userName",
+    Header: <FormattedMessage {...messages.DataQualityIssues} />,
+    Cell: ({ cell: { value } }) => (
+      <DownloadDataCell value={value} source="usergroup" />
+    ),
+    disableSortBy: true,
+    defaultCanSort: false,
+  },
+];

--- a/src/components/userGroup/userGroupResults.js
+++ b/src/components/userGroup/userGroupResults.js
@@ -1,29 +1,25 @@
-import React, { useState } from "react";
+import React from "react";
+import { useSelector } from "react-redux";
+import { useTable, useSortBy } from "react-table";
 import { FormattedMessage } from "react-intl";
-import { DownloadFileLink } from "../downloadLink";
 import messages from "./messages";
 import { Error } from "../formResponses";
 import { UserGroupErrorMessage } from "./userGroupError";
+import { SortDownIcon, SortIcon, SortUpIcon } from "../../assets/svgIcons";
 
-const featureActionCount = (array, feature, action) => {
-  let x = array.filter(
-    (i) => i["feature"] === feature && i["action"] === action
-  );
-  return x[0] ? x[0]["count"] : 0;
-};
+export function UserGroupResultsTable({ columns, data, userDataCheck }) {
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable(
+      {
+        columns,
+        data,
+      },
+      useSortBy
+    );
 
-const USER_GROUP_COLUMN_HEADINGS = [
-  { title: "Mapper" },
-  { title: "CreatedBuildings" },
-  { title: "ModifiedBuildings" },
-  { title: "CreatedHighways" },
-  { title: "ModifiedHighways" },
-  { title: "DataQualityIssues" },
-];
+  const downloadError = useSelector((state) => state.mapathon.downloadError);
 
-export const UserGroupResults = ({ users, startDate, endDate }) => {
-  const [downloadError, setDownloadError] = useState(null);
-  if (users.length > 0) {
+  if (userDataCheck) {
     return (
       <>
         {downloadError && (
@@ -31,68 +27,63 @@ export const UserGroupResults = ({ users, startDate, endDate }) => {
             <UserGroupErrorMessage error={downloadError} />
           </Error>
         )}
-        <table className="table-fixed mt-5 mx-auto">
-          <thead>
-            <tr>
-              {USER_GROUP_COLUMN_HEADINGS.map((i, n) => (
-                <th
-                  key={n}
-                  className="w-1/6 text-left font-bold text-xl px-7 py-4"
-                >
-                  <FormattedMessage {...messages[i.title]} />
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {users.map((i) => {
-              return (
-                <tr key={i["userId"]}>
-                  <td className="py-2 px-7 text-lg">
-                    <a
-                      href={`https://www.openstreetmap.org/user/${i["userName"]}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="hover:underline"
-                    >
-                      {i["userName"]}
-                    </a>
-                  </td>
-                  <td className="py-2 px-7 text-lg">
-                    {featureActionCount(i["stats"], "building", "create")}
-                  </td>
-                  <td className="py-2 px-7 text-lg">
-                    {featureActionCount(i["stats"], "building", "modify")}
-                  </td>
-                  <td className="py-2 px-7 text-lg">
-                    {featureActionCount(i["stats"], "highway", "create")}
-                  </td>
-                  <td className="py-2 px-7 text-lg">
-                    {featureActionCount(i["stats"], "highway", "modify")}
-                  </td>
-                  <td className="py-2 px-7 text-lg">
-                    Download &nbsp;
-                    <DownloadFileLink
-                      username={i["userName"]}
-                      type={"csv"}
-                      startDate={startDate}
-                      endDate={endDate}
-                      setDownloadError={setDownloadError}
-                    />
-                    /
-                    <DownloadFileLink
-                      username={i["userName"]}
-                      type={"json"}
-                      startDate={startDate}
-                      endDate={endDate}
-                      setDownloadError={setDownloadError}
-                    />
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="flex flex-col">
+          <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">
+              <div className="overflow-x-auto"></div>
+              <table {...getTableProps()} className="min-w-full">
+                <thead className="border-b">
+                  {headerGroups.map((headerGroup) => (
+                    <tr {...headerGroup.getHeaderGroupProps()}>
+                      {headerGroup.headers.map((column) => (
+                        <th
+                          scope="col"
+                          className="text-xl font-semibold px-6 py-4 text-left"
+                          {...column.getHeaderProps(
+                            column.getSortByToggleProps()
+                          )}
+                        >
+                          <span className="inline ">
+                            {column.render("Header")} &nbsp;
+                            {column.canSort &&
+                              (column.isSorted ? (
+                                column.isSortedDesc ? (
+                                  <SortDownIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                ) : (
+                                  <SortUpIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                )
+                              ) : (
+                                <SortIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                              ))}
+                          </span>
+                        </th>
+                      ))}
+                    </tr>
+                  ))}
+                </thead>
+                <tbody {...getTableBodyProps()}>
+                  {rows.map((row, i) => {
+                    prepareRow(row);
+                    return (
+                      <tr {...row.getRowProps()} className="border-b">
+                        {row.cells.map((cell) => {
+                          return (
+                            <td
+                              className="text-lg font-light px-6 py-4 whitespace-nowrap"
+                              {...cell.getCellProps()}
+                            >
+                              {cell.render("Cell")}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </>
     );
   } else {
@@ -104,4 +95,4 @@ export const UserGroupResults = ({ users, startDate, endDate }) => {
       </div>
     );
   }
-};
+}

--- a/src/context/userGroupContext.js
+++ b/src/context/userGroupContext.js
@@ -1,0 +1,33 @@
+import React, { useReducer } from "react";
+import { addDays } from "date-fns";
+
+let reducer = (data, newData) => {
+  return { ...data, ...newData };
+};
+
+const initialFormData = {
+  startDate: addDays(new Date(), -29),
+  endDate: new Date(),
+  TMProjectIds: "",
+  mapathonHashtags: "",
+  usernames: "",
+};
+
+const UserGroupContext = React.createContext();
+
+function UserGroupContextProvider(props) {
+  const [formData, setFormData] = useReducer(reducer, initialFormData);
+
+  return (
+    <UserGroupContext.Provider
+      value={{
+        formData,
+        setFormData,
+      }}
+    >
+      {props.children}
+    </UserGroupContext.Provider>
+  );
+}
+
+export { UserGroupContext, UserGroupContextProvider };

--- a/src/features/form/formSlice.js
+++ b/src/features/form/formSlice.js
@@ -5,6 +5,7 @@ export const MapathonFormSlice = createSlice({
   initialState: {
     triggerSubmit: false,
     isLoading: false,
+    downloadError: null,
   },
   reducers: {
     setTriggerSubmit: (state, action) => {
@@ -13,9 +14,13 @@ export const MapathonFormSlice = createSlice({
     setLoading: (state, action) => {
       state.isLoading = action.payload;
     },
+    setDownloadError: (state, action) => {
+      state.downloadError = action.payload;
+    },
   },
 });
 
-export const { setTriggerSubmit, setLoading } = MapathonFormSlice.actions;
+export const { setTriggerSubmit, setLoading, setDownloadError } =
+  MapathonFormSlice.actions;
 
 export default MapathonFormSlice.reducer;

--- a/src/hooks/useDownloadFile.js
+++ b/src/hooks/useDownloadFile.js
@@ -1,26 +1,29 @@
 import { useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+import { setDownloadError } from "../features/form/formSlice";
 
 export const useDownloadFile = ({ fetchFile, getFileName }) => {
   const ref = useRef(null);
+
+  const dispatch = useDispatch();
   const [fileData, setFileData] = useState();
   const [fileName, setFileName] = useState();
-  const [fileError, setFileError] = useState(null);
 
   const download = async () => {
     try {
       const { data } = await fetchFile();
       setFileData(data);
       setFileName(getFileName());
-      setFileError(null);
+      dispatch(setDownloadError(null));
       ref.current?.click();
     } catch (error) {
       if (error.response.status === 500) {
-        setFileError(error.response.data);
+        dispatch(setDownloadError(error.response.data));
       } else {
-        setFileError(error.response.data.detail[0]["msg"]);
+        dispatch(setDownloadError(error.response.data.detail[0]["msg"]));
       }
     }
   };
 
-  return { download, ref, fileData, fileName, fileError };
+  return { download, ref, fileData, fileName };
 };

--- a/src/queries/getMapathonReport.js
+++ b/src/queries/getMapathonReport.js
@@ -1,32 +1,19 @@
 import axios from "axios";
 import { API_URL } from "../config";
 import * as safeStorage from "../utils/safeStorage";
+import {
+  convertStringToArray,
+  convertStringToNumberArray,
+} from "../utils/formatInputs";
 
 const formatMapathonRequestData = (requestData) => {
   const { startDate, endDate, TMProjectIds, mapathonHashtags } = requestData;
   let body = {
     fromTimestamp: startDate.toISOString().replace("Z", ""),
     toTimestamp: endDate.toISOString().replace("Z", ""),
-    projectIds: [],
-    hashtags: [],
+    projectIds: convertStringToNumberArray(TMProjectIds),
+    hashtags: convertStringToArray(mapathonHashtags),
   };
-
-  if (TMProjectIds.length > 0) {
-    body["projectIds"] = TMProjectIds.split(",")
-      .map((i) => Number(i))
-      .filter((x) => x !== 0);
-  }
-
-  if (mapathonHashtags.length > 0) {
-    let arr = mapathonHashtags.split(",").map((i) => {
-      i = i.toString().trim();
-      if (i.startsWith("#")) i = i.substr(1);
-      return i;
-    });
-    let pattern = /([a-zA-Z0-9])\w+/gi;
-    body["hashtags"] = arr.filter((j) => j.match(pattern));
-  }
-
   return body;
 };
 

--- a/src/utils/formatInputs.js
+++ b/src/utils/formatInputs.js
@@ -3,7 +3,10 @@ export const convertStringToNumberArray = (input) => {
   if (input.length > 0) {
     result = input
       .split(",")
-      .map((i) => Number(i))
+      .map((i) => {
+        i.trim();
+        return Number(i);
+      })
       .filter((x) => x !== 0);
   }
   return result;

--- a/src/utils/mapathonDataUtils.js
+++ b/src/utils/mapathonDataUtils.js
@@ -12,7 +12,7 @@ const filterTMStatsById = (arr, id) => {
   return arr.filter((i) => i["userId"] === id);
 };
 
-export const aggregateUserData = (obj) => {
+export const aggregateMapathonUserData = (obj) => {
   const arr = [];
   let tasksMappedStats = obj.tmStats[0]["tasksMapped"];
   let tasksValidatedStats = obj.tmStats[0]["tasksValidated"];

--- a/src/utils/userGroupUtils.js
+++ b/src/utils/userGroupUtils.js
@@ -1,0 +1,20 @@
+export const featureActionCount = (array, feature, action) => {
+  let x = array.filter(
+    (i) => i["feature"] === feature && i["action"] === action
+  );
+  return x[0] ? x[0]["count"] : 0;
+};
+
+export const aggregateUserGroupData = (obj) => {
+  const arr = [];
+  obj.forEach((i) => {
+    arr.push({
+      ...i,
+      createdBuildings: featureActionCount(i["stats"], "building", "create"),
+      modifiedBuildings: featureActionCount(i["stats"], "building", "modify"),
+      createdHighways: featureActionCount(i["stats"], "highway", "create"),
+      modifiedHighways: featureActionCount(i["stats"], "highway", "modify"),
+    });
+  });
+  return arr;
+};

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -13,7 +13,7 @@ import {
 import { MapathonRedirectButton } from "../components/auth";
 import { setTriggerSubmit } from "../features/form/formSlice";
 import { MiniNavBar } from "../components/nav/navbar";
-import { aggregateUserData } from "../utils/mapathonDataUtils";
+import { aggregateMapathonUserData } from "../utils/mapathonDataUtils";
 import { MapathonDetailedTableHeaders } from "../components/mapathon/constants";
 
 const MAPATHON_PAGES = [
@@ -84,7 +84,7 @@ export const MapathonDetailedReport = () => {
       )}
       {data && (
         <MapathonDetailedResultsTable
-          data={aggregateUserData(data)}
+          data={aggregateMapathonUserData(data)}
           columns={MapathonDetailedTableHeaders}
         />
       )}

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -8,8 +8,7 @@ import {
 } from "../queries/index";
 import {
   MapathonSummaryResults,
-  MapathonDetailedResults,
-  Table,
+  MapathonDetailedResultsTable,
 } from "../components/mapathon/mapathonResults";
 import { MapathonRedirectButton } from "../components/auth";
 import { setTriggerSubmit } from "../features/form/formSlice";
@@ -83,9 +82,8 @@ export const MapathonDetailedReport = () => {
       {(isLoading || triggeredLoading) && (
         <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
       )}
-      {/* {data && <MapathonDetailedResults data={data} />} */}
       {data && (
-        <Table
+        <MapathonDetailedResultsTable
           data={aggregateUserData(data)}
           columns={MapathonDetailedTableHeaders}
         />

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -9,10 +9,13 @@ import {
 import {
   MapathonSummaryResults,
   MapathonDetailedResults,
+  Table,
 } from "../components/mapathon/mapathonResults";
 import { MapathonRedirectButton } from "../components/auth";
 import { setTriggerSubmit } from "../features/form/formSlice";
 import { MiniNavBar } from "../components/nav/navbar";
+import { aggregateUserData } from "../utils/mapathonDataUtils";
+import { MapathonDetailedTableHeaders } from "../components/mapathon/constants";
 
 const MAPATHON_PAGES = [
   { pageTitle: "Mapathon Summary Report", pageURL: "/mapathon-report/summary" },
@@ -80,7 +83,13 @@ export const MapathonDetailedReport = () => {
       {(isLoading || triggeredLoading) && (
         <div className="mx-auto text-center w-1/4 p-1 mt-5">Loading...</div>
       )}
-      {data && <MapathonDetailedResults data={data} />}
+      {/* {data && <MapathonDetailedResults data={data} />} */}
+      {data && (
+        <Table
+          data={aggregateUserData(data)}
+          columns={MapathonDetailedTableHeaders}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
**What does this PR do?** 
This PR adds functionality allowing users to sort different table columns either by ascending or descending order on both the mapathon detailed and user group reports pages. 

In use:
- [React-Table](https://react-table-v7.tanstack.com/)
- [tailwind components](https://tailwind-elements.com/docs/standard/components/tables/)

**How to test:**
- Pull the branch `git fetch origin && git checkout feature/add-table-functionality`. 
- There's a new dependency in use, i.e. react-table. Hence, we install packages with: `npm i` 
- Start the server with `npm start`
- Go to `http://127.0.0.1:3000/mapathon-report/detailed` and submit form data. 
- Click on different table column headers to sort either by ascending or descending order when the results table is displayed.

**Screenshot:** 
![Screenshot 2022-04-15 at 07 37 28](https://user-images.githubusercontent.com/31903212/163519219-4c72eb69-4908-4557-9ca0-fa1c121571b9.png)

**Related issues:** 
- Fix #70 