### PR TITLE
Users can download reports as CSV 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "mapbox-gl": "^2.5.1",
         "prettier": "^2.5.1",
         "react": "^17.0.2",
+        "react-csv": "^2.2.2",
         "react-datepicker": "^4.2.1",
         "react-dom": "^17.0.2",
         "react-intl": "^5.20.12",
@@ -18152,6 +18153,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/react-csv": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
+      "integrity": "sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw=="
     },
     "node_modules/react-datepicker": {
       "version": "4.3.0",
@@ -38084,6 +38090,11 @@
         "regenerator-runtime": "^0.13.7",
         "whatwg-fetch": "^3.4.1"
       }
+    },
+    "react-csv": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
+      "integrity": "sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw=="
     },
     "react-datepicker": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mapbox-gl": "^2.5.1",
     "prettier": "^2.5.1",
     "react": "^17.0.2",
+    "react-csv": "^2.2.2",
     "react-datepicker": "^4.2.1",
     "react-dom": "^17.0.2",
     "react-intl": "^5.20.12",

--- a/src/components/download.js
+++ b/src/components/download.js
@@ -1,10 +1,14 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 import React, { useContext } from "react";
 import axios from "axios";
+import { CSVLink } from "react-csv";
+import { format } from "date-fns";
 import { API_URL } from "../config";
 import { useDownloadFile } from "../hooks/useDownloadFile";
 import { MapathonContext } from "../context/mapathonContext";
 import { UserGroupContext } from "../context/userGroupContext";
+import { MapathonReportCSVHeaders } from "./mapathon/constants";
+import { UserGroupReportCSVHeaders } from "./userGroup/constants";
 
 export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
   const fetchFile = () => {
@@ -53,7 +57,11 @@ export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
 
 export const DownloadDataCell = ({ value, source }) => {
   const { formData } = useContext(
-    source === "mapathon" ? MapathonContext : UserGroupContext
+    source === "mapathon"
+      ? MapathonContext
+      : source === "userGroup"
+      ? UserGroupContext
+      : []
   );
   return (
     <>
@@ -72,5 +80,41 @@ export const DownloadDataCell = ({ value, source }) => {
         endDate={formData.endDate}
       />
     </>
+  );
+};
+
+export const DownloadCSVButton = ({ data, source }) => {
+  const { formData } = useContext(
+    source === "mapathon"
+      ? MapathonContext
+      : source === "userGroup"
+      ? UserGroupContext
+      : []
+  );
+
+  const headers =
+    source === "mapathon"
+      ? MapathonReportCSVHeaders
+      : source === "userGroup"
+      ? UserGroupReportCSVHeaders
+      : [];
+
+  const csvDateRange = `${format(formData.startDate, "dd/MM/yyyy")} - ${format(
+    formData.endDate,
+    "dd/MM/yyyy"
+  )}`;
+
+  return (
+    <div className="text-right m-4 text-lg">
+      <CSVLink
+        data={data}
+        headers={headers}
+        filename={`${csvDateRange} ${source} Report.csv`}
+        className="bg-blue-grey text-white py-2 px-4"
+        target="_blank"
+      >
+        Download CSV
+      </CSVLink>
+    </div>
   );
 };

--- a/src/components/mapathon/constants.js
+++ b/src/components/mapathon/constants.js
@@ -62,3 +62,38 @@ export const MapathonDetailedTableHeaders = [
     defaultCanSort: false,
   },
 ];
+
+export const MapathonReportCSVHeaders = [
+  {
+    key: "username",
+    label: "Mapper",
+  },
+  {
+    key: "addedBuildings",
+    label: "Added Buildings",
+  },
+  {
+    key: "modifiedBuildings",
+    label: "Modified Buildings",
+  },
+  {
+    key: "createdHighways",
+    label: "Added Highways",
+  },
+  {
+    key: "mappedTasks",
+    label: "Mapped Tasks",
+  },
+  {
+    key: "validatedTasks",
+    label: "Validated Tasks",
+  },
+  {
+    key: "timeSpentMapping",
+    label: "Time Spent Mapping",
+  },
+  {
+    key: "timeSpentValidating",
+    label: "Time Spent Validating",
+  },
+];

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -6,6 +6,7 @@ import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
 import { useSelector } from "react-redux";
 import { SortDownIcon, SortIcon, SortUpIcon } from "../../assets/svgIcons";
+import { DownloadCSVButton } from "../download";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -83,6 +84,7 @@ export function MapathonDetailedResultsTable({ columns, data }) {
             <MapathonErrorMessage error={downloadError} />
           </Error>
         )}
+        <DownloadCSVButton data={data} source={"mapathon"} />
         <div className="flex flex-col">
           <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -172,6 +172,18 @@ export default defineMessages({
     id: "reports.mapathon.detailed.column.timeSpentValidating",
     defaultMessage: "Time Spent Validating (s)",
   },
+  Editors: {
+    id: "reports.mapathon.detailed.column.editorsUsed",
+    defaultMessage: "Editors used",
+  },
+  userId: {
+    id: "reports.mapathon.detailed.column.userId",
+    defaultMessage: "User Id",
+  },
+  TotalBuildings: {
+    id: "reports.mapathon.detailed.column.buildings.total",
+    defaultMessage: "Total number of buildings",
+  },
   DataQualityIssues: {
     id: "reports.mapathon.detailed.column.dataQualityIssues",
     defaultMessage: "Data Quality Issues",

--- a/src/components/userGroup/constants.js
+++ b/src/components/userGroup/constants.js
@@ -40,9 +40,32 @@ export const UserGroupColumnHeadings = [
     accessor: "userName",
     Header: <FormattedMessage {...messages.DataQualityIssues} />,
     Cell: ({ cell: { value } }) => (
-      <DownloadDataCell value={value} source="usergroup" />
+      <DownloadDataCell value={value} source="userGroup" />
     ),
     disableSortBy: true,
     defaultCanSort: false,
+  },
+];
+
+export const UserGroupReportCSVHeaders = [
+  {
+    key: "userName",
+    label: "Mapper",
+  },
+  {
+    key: "createdBuildings",
+    label: "Created Buildings",
+  },
+  {
+    key: "modifiedBuildings",
+    label: "Modified Buildings",
+  },
+  {
+    key: "createdHighways",
+    label: "Added Highways",
+  },
+  {
+    key: "modifiedHighways",
+    label: "Modified Highways",
   },
 ];

--- a/src/components/userGroup/userGroupResults.js
+++ b/src/components/userGroup/userGroupResults.js
@@ -6,6 +6,7 @@ import messages from "./messages";
 import { Error } from "../formResponses";
 import { UserGroupErrorMessage } from "./userGroupError";
 import { SortDownIcon, SortIcon, SortUpIcon } from "../../assets/svgIcons";
+import { DownloadCSVButton } from "../download";
 
 export function UserGroupResultsTable({ columns, data, userDataCheck }) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -27,6 +28,7 @@ export function UserGroupResultsTable({ columns, data, userDataCheck }) {
             <UserGroupErrorMessage error={downloadError} />
           </Error>
         )}
+        <DownloadCSVButton data={data} source={"userGroup"} />
         <div className="flex flex-col">
           <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">


### PR DESCRIPTION
**What does this PR do?** 
This PR adds functionality to enable users download the reports on both the mapathon detailed and user group report pages. 

In use:
- [React-CSV](https://www.npmjs.com/package/react-csv)

**How to test:**
- Pull the branch using `git fetch origin && git checkout feature/download-reports`
- Install dependencies with: `npm i`
- Start the server with `npm start`
- Go to `http://127.0.0.1:3000/mapathon-report/detailed` or `http://127.0.0.1:3000/user-report` and submit form data.
- Click the `Download CSV` button that appears at the top of the returned table results. 
- Your CSV file report can be opened in Excel or Sheets. 

Related issues:
- Fixes #73 