### PR TITLE
Add Today Checkpoint on Mapathon Report Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,13 +5641,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001261",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -28526,9 +28532,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001261",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA=="
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import DatePicker from "react-datepicker";
-import { getTime } from "date-fns";
+import { getTime, setHours, setMinutes, setSeconds } from "date-fns";
 import { FormattedMessage, useIntl } from "react-intl";
 import "react-datepicker/dist/react-datepicker.css";
 import { SubmitButton } from "../button";
+import { SwitchToggle } from "../toggle";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
 import { setLoading, setTriggerSubmit } from "../../features/form/formSlice";
@@ -20,11 +21,25 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
   const { mapathonFormData, setMapathonFormData } = useContext(FormContext);
   const [formError, setFormError] = useState(null);
   const triggerSubmit = useSelector((state) => state.mapathon.triggerSubmit);
+  const [today, setToday] = useState(false);
 
   useEffect(() => {
     if (error) setFormError(error);
     else setFormError(null);
   }, [mapathonFormData, error]);
+
+  useEffect(() => {
+    if (today) {
+      let startDate = setHours(setMinutes(setSeconds(new Date(), 0), 0), 0);
+      let endDate = setHours(setMinutes(setSeconds(new Date(), 59), 59), 23);
+      setFormData({
+        ...formData,
+        startDate,
+        endDate,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [today]);
 
   const fetchData = () => {
     try {
@@ -65,6 +80,11 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
 
   return (
     <>
+      <SwitchToggle
+        label="Today"
+        isChecked={today}
+        handleChange={() => setToday(!today)}
+      />
       <form onSubmit={handleSubmit} className="mt-4 px-4">
         <div className="grid grid-cols-8 gap-4">
           <div className="space-y-20 py-2 col-span-2">
@@ -85,6 +105,7 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
                   });
                 }}
                 showTimeSelect
+                readOnly={today}
                 timeIntervals={15}
                 timeCaption="Time"
                 dateFormat="d MMMM, yyyy h:mm aa"
@@ -112,6 +133,7 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
                   getTime(mapathonFormData.startDate) < getTime(time)
                 }
                 showTimeSelect
+                readOnly={today}
                 timeIntervals={15}
                 timeCaption="Time"
                 dateFormat=" d MMMM, yyyy h:mm aa"

--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -32,8 +32,8 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
     if (today) {
       let startDate = setHours(setMinutes(setSeconds(new Date(), 0), 0), 0);
       let endDate = setHours(setMinutes(setSeconds(new Date(), 59), 59), 23);
-      setFormData({
-        ...formData,
+      setMapathonFormData({
+        ...mapathonFormData,
         startDate,
         endDate,
       });

--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+export const SwitchToggle = ({ label, isChecked, handleChange }) => {
+  return (
+    <div className="flex items-center justify-start w-full my-4 px-4">
+      <div className="mr-3 text-xl">{label}</div>
+      <label
+        htmlFor={`${label}-toggle`}
+        className="flex items-center cursor-pointer"
+      >
+        <div className="relative">
+          <input
+            type="checkbox"
+            id={`${label}-toggle`}
+            className="sr-only"
+            checked={isChecked}
+            onChange={handleChange}
+          />
+          <div
+            className={`block w-16 h-8 rounded-full transition duration-300 ease-in-out translate-x-full ${
+              isChecked ? "bg-red" : "bg-blue-grey"
+            }`}
+          />
+          <div
+            className={`absolute top-0 left-0 bg-white w-8 h-8 border rounded-full transition duration-300 ease-in-out ${
+              isChecked ? "transform translate-x-full" : ""
+            }`}
+          />
+        </div>
+      </label>
+    </div>
+  );
+};


### PR DESCRIPTION
**How to test:**
- Pull and check out branch: `git pull origin && git checkout feature/today-checkpoint`
- Install dependencies: `npm i`
- Start server: `npm start`
- Go to `http://127.0.0.1:3000/mapathon-report/summary` to test out the today toggle. 

**Related issues:**
- Fixes #75 

**Screenshots:**
1. Unchecked: user can select any date and time range.
<img width="361" alt="today - unchecked" src="https://user-images.githubusercontent.com/31903212/167156761-dd2cf5c5-8604-4a17-94c0-585d57b04d23.png">

2. Checked: The date and time ranges switch to the current day between 12:00 am to 11:59 pm according to a user's timezone. The start and end date fields are locked so a  user cannot change them.
<img width="362" alt="today - checked" src="https://user-images.githubusercontent.com/31903212/167157231-60ebc9aa-66cb-449a-baf6-d43e58b5200d.png">

 