### PR TITLE
Add Error Fallback Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-csv": "^2.2.2",
         "react-datepicker": "^4.2.1",
         "react-dom": "^17.0.2",
+        "react-error-boundary": "^3.1.4",
         "react-intl": "^5.20.12",
         "react-placeholder": "^4.1.0",
         "react-query": "^3.27.0",
@@ -18429,6 +18430,21 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-error-overlay": {
@@ -38324,6 +38340,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-csv": "^2.2.2",
     "react-datepicker": "^4.2.1",
     "react-dom": "^17.0.2",
+    "react-error-boundary": "^3.1.4",
     "react-intl": "^5.20.12",
     "react-placeholder": "^4.1.0",
     "react-query": "^3.27.0",

--- a/src/App.js
+++ b/src/App.js
@@ -5,12 +5,14 @@ import {
   Route,
   Redirect,
 } from "react-router-dom";
+import { ErrorBoundary } from "react-error-boundary";
 import { ProtectedRoute } from "./components/protectedRoute";
 import { MATOMO_ID } from "./config";
 import { FormContextProvider } from "./context/formContext";
 import { TrackingBanner } from "./components/banner";
 import Header from "./components/nav/header";
 import { LoginCallback } from "./components/auth";
+import { FallbackComponent } from "./components/error";
 import { About } from "./views/About";
 import { Home } from "./views/Home";
 import { Reports } from "./views/Reports";
@@ -23,7 +25,7 @@ import { NotFoundPage } from "./views/NotFound";
 
 function App() {
   return (
-    <>
+    <ErrorBoundary FallbackComponent={FallbackComponent}>
       <Router>
         <Header />
         <div>
@@ -50,7 +52,7 @@ function App() {
         </div>
       </Router>
       {MATOMO_ID && <TrackingBanner />}
-    </>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/error.js
+++ b/src/components/error.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { Button } from "./button";
+import messages from "./messages";
+
+export const FallbackComponent = ({ error }) => {
+  const handleClick = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className=" mx-auto">
+        <div className="text-xl w-full text-center" title="error" role="img">
+          <FormattedMessage {...messages.fallbackError} />
+          {"!"}
+        </div>
+        <div className="p-3 text-center">
+          <p className="text-lg text-red">&#123; {error.message} &#125;</p>
+        </div>
+        <div className="py-2 text-lg text-center">
+          <a
+            className="bg-red text-white py-2 px-4 mx-2"
+            href="https://github.com/hotosm/galaxy-ui/issues"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <FormattedMessage {...messages.reportIssue} />
+          </a>
+          <Button
+            onClick={handleClick}
+            styles={"text-red bg-white border border-tan py-1 px-7 mx-2"}
+          >
+            <FormattedMessage {...messages.tryAgain} />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -205,4 +205,16 @@ export default defineMessages({
     id: "about.footer.contact",
     defaultMessage: "Reach out on {GithubLink} or {SlackLink}.",
   },
+  fallbackError: {
+    id: "error.fallback.heading",
+    defaultMessage: "It looks like something went wrong",
+  },
+  reportIssue: {
+    id: "error.fallback.link.report",
+    defaultMessage: "Report Issue",
+  },
+  tryAgain: {
+    id: "error.fallback.button.retry",
+    defaultMessage: "Try Again",
+  },
 });


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a fallback UI component when site rendering fails due to errors, possibly from within the component or server-related queries.

**Screenshot example:**
<img width="533" alt="error fallback" src="https://user-images.githubusercontent.com/31903212/167441472-682d6682-1bea-4e56-9cdf-614b9f9a6f32.png">

**Related issues:**
- Fixes #81 