### PR TITLE
Add tooltips to Mapathon Detailed task & time stats headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
         "react-table": "^7.7.0",
+        "reactjs-popup": "^2.0.5",
         "web-vitals": "^1.0.1",
         "webfontloader": "^1.6.28"
       },
@@ -18775,6 +18776,18 @@
       },
       "peerDependencies": {
         "react": "^16.8.3 || ^17.0.0-0"
+      }
+    },
+    "node_modules/reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {
@@ -38570,6 +38583,12 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
       "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==",
+      "requires": {}
+    },
+    "reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
       "requires": {}
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
     "react-table": "^7.7.0",
+    "reactjs-popup": "^2.0.5",
     "web-vitals": "^1.0.1",
     "webfontloader": "^1.6.28"
   },

--- a/src/assets/svgIcons/index.js
+++ b/src/assets/svgIcons/index.js
@@ -1,3 +1,4 @@
 export { BanIcon } from "./ban";
 export { SortIcon, SortDownIcon, SortUpIcon } from "./sortIcons";
 export { SpinnerIcon } from "./spinner";
+export { QuestionIcon } from "./question";

--- a/src/assets/svgIcons/question.js
+++ b/src/assets/svgIcons/question.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+// Icon produced by FontAwesome project: https://github.com/FortAwesome/Font-Awesome/
+// License: CC-By 4.0
+export class QuestionIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        {...this.props}
+      >
+        <path
+          fill="currentColor"
+          d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 464c-114.7 0-208-93.31-208-208S141.3 48 256 48s208 93.31 208 208S370.7 464 256 464zM256 336c-18 0-32 14-32 32s13.1 32 32 32c17.1 0 32-14 32-32S273.1 336 256 336zM289.1 128h-51.1C199 128 168 159 168 198c0 13 11 24 24 24s24-11 24-24C216 186 225.1 176 237.1 176h51.1C301.1 176 312 186 312 198c0 8-4 14.1-11 18.1L244 251C236 256 232 264 232 272V288c0 13 11 24 24 24S280 301 280 288V286l45.1-28c21-13 34-36 34-60C360 159 329 128 289.1 128z"
+        />
+      </svg>
+    );
+  }
+}

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -94,7 +94,7 @@ export function MapathonDetailedResultsTable({ columns, data }) {
           <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">
               <div className="overflow-x-auto"></div>
-              <table {...getTableProps()} className="min-w-full">
+              <table {...getTableProps()} className="min-w-full border">
                 <thead className="border-b">
                   {headerGroups.map((headerGroup) => (
                     <tr {...headerGroup.getHeaderGroupProps()}>

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -1,12 +1,18 @@
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { useSelector } from "react-redux";
 import { useTable, useSortBy } from "react-table";
 import messages from "../messages";
 import { Error } from "../formResponses";
 import { MapathonErrorMessage } from "./mapathonError";
-import { useSelector } from "react-redux";
-import { SortDownIcon, SortIcon, SortUpIcon } from "../../assets/svgIcons";
+import {
+  QuestionIcon,
+  SortDownIcon,
+  SortIcon,
+  SortUpIcon,
+} from "../../assets/svgIcons";
 import { DownloadCSVButton } from "../download";
+import { Tooltip } from "../tooltip";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -63,7 +69,7 @@ export const MapathonSummaryResults = ({ data }) => {
 };
 
 export function MapathonDetailedResultsTable({ columns, data }) {
-  // Use the state and functions returned from useTable to build your UI
+  const intl = useIntl();
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
       {
@@ -75,7 +81,6 @@ export function MapathonDetailedResultsTable({ columns, data }) {
 
   const downloadError = useSelector((state) => state.mapathon.downloadError);
 
-  // Render the UI for your table
   if (data.length > 0) {
     return (
       <>
@@ -93,29 +98,50 @@ export function MapathonDetailedResultsTable({ columns, data }) {
                 <thead className="border-b">
                   {headerGroups.map((headerGroup) => (
                     <tr {...headerGroup.getHeaderGroupProps()}>
-                      {headerGroup.headers.map((column) => (
-                        <th
-                          scope="col"
-                          className="text-xl font-semibold px-6 py-4 text-left"
-                          {...column.getHeaderProps(
-                            column.getSortByToggleProps()
-                          )}
-                        >
-                          <span className="inline ">
-                            {column.render("Header")} &nbsp;
-                            {column.canSort &&
-                              (column.isSorted ? (
-                                column.isSortedDesc ? (
-                                  <SortDownIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
-                                ) : (
-                                  <SortUpIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
-                                )
+                      {headerGroup.headers.map((column) => {
+                        const tooltipKeys = [
+                          "timeSpentMapping",
+                          "timeSpentValidating",
+                          "validatedTasks",
+                          "mappedTasks",
+                        ];
+                        let showTooltip = tooltipKeys.includes(column.id);
+                        return (
+                          <th
+                            scope="col"
+                            className="text-xl font-semibold px-6 py-4 text-left"
+                            {...column.getHeaderProps(
+                              column.getSortByToggleProps()
+                            )}
+                          >
+                            <span className="inline ">
+                              {column.render("Header")} &nbsp;
+                              {showTooltip ? (
+                                <Tooltip
+                                  position={"top center"}
+                                  content={intl.formatMessage(
+                                    messages.mapathonTooltip
+                                  )}
+                                >
+                                  <QuestionIcon className="w-3 h-3 text-red" />
+                                </Tooltip>
                               ) : (
-                                <SortIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
-                              ))}
-                          </span>
-                        </th>
-                      ))}
+                                ""
+                              )}
+                              {column.canSort &&
+                                (column.isSorted ? (
+                                  column.isSortedDesc ? (
+                                    <SortDownIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                  ) : (
+                                    <SortUpIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                  )
+                                ) : (
+                                  <SortIcon className="w-3 h-3 ml-1 inline text-blue-grey" />
+                                ))}
+                            </span>
+                          </th>
+                        );
+                      })}
                     </tr>
                   ))}
                 </thead>

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -109,7 +109,7 @@ export function MapathonDetailedResultsTable({ columns, data }) {
                         return (
                           <th
                             scope="col"
-                            className="text-xl font-semibold px-6 py-4 text-left"
+                            className="text-lg font-semibold px-6 py-4 text-left"
                             {...column.getHeaderProps(
                               column.getSortByToggleProps()
                             )}

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -146,15 +146,15 @@ export default defineMessages({
   },
   AddedBuildings: {
     id: "reports.mapathon.detailed.column.buildingsAdded",
-    defaultMessage: "Buildings Added",
+    defaultMessage: "# Buildings Added",
   },
   ModifiedBuildings: {
     id: "reports.mapathon.detailed.column.buildingsModified",
-    defaultMessage: "Buildings Modified",
+    defaultMessage: "# Buildings Modified",
   },
   AddedHighways: {
     id: "reports.mapathon.detailed.column.highwaysAdded",
-    defaultMessage: "Highways Added",
+    defaultMessage: "# Highways Added",
   },
   MappedTasks: {
     id: "reports.mapathon.detailed.column.tasksMapped",

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -192,6 +192,11 @@ export default defineMessages({
     id: "reports.mapathon.detailed.results.no.data",
     defaultMessage: "No Data Found!",
   },
+  mapathonTooltip: {
+    id: "reports.mapathon.detailed.stats.tooltip",
+    defaultMessage:
+      "The following statistics: tasks mapped, tasks validated, time spent mapping, and time spent validating are derived using either Tasking Manager project ids or Tasking Manager specific hashtags, e.g. hotosm-project-1.",
+  },
   footerOrganisation: {
     id: "about.footer.organisation",
     defaultMessage: "This project is under development by {OrganisationLink}.",

--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -1,0 +1,24 @@
+import React from "react";
+import Popup from "reactjs-popup";
+
+const TooltipCard = ({ content }) => {
+  return (
+    <div className="max-w-sm rounded overflow-hidden shadow-lg bg-blue-dark text-white p-4">
+      <p className="text-base font-light">{content}</p>
+    </div>
+  );
+};
+
+export const Tooltip = ({ content, position, children }) => {
+  return (
+    <Popup
+      trigger={<button className="button">{children}</button>}
+      position={position}
+      closeOnDocumentClick
+      on={["hover"]}
+      arrow={position !== "center center"}
+    >
+      <TooltipCard content={content} />
+    </Popup>
+  );
+};

--- a/src/components/userGroup/messages.js
+++ b/src/components/userGroup/messages.js
@@ -44,19 +44,19 @@ export default defineMessages({
   },
   CreatedBuildings: {
     id: "reports.user.group.table.column.buildingsCreated",
-    defaultMessage: "Buildings Created",
+    defaultMessage: "# Buildings Created",
   },
   ModifiedBuildings: {
     id: "reports.user.group.table.column.buildingsModified",
-    defaultMessage: "Buildings Modified",
+    defaultMessage: "# Buildings Modified",
   },
   CreatedHighways: {
     id: "reports.user.group.table.column.highwaysCreated",
-    defaultMessage: "Highways Created",
+    defaultMessage: "# Highways Created",
   },
   ModifiedHighways: {
     id: "reports.user.group.table.column.highwaysModified",
-    defaultMessage: "Highways Modified",
+    defaultMessage: "# Highways Modified",
   },
   DataQualityIssues: {
     id: "reports.user.group.table.column.dataQualityIssues",


### PR DESCRIPTION
This PR adds tooltips to the time and task stats headers in the mapathon detailed results table. The tooltips give information on how these stats are derived. 

**New dependency:**
- [reactjs-popup](https://react-popup.elazizi.com/react-tooltip): used to create the tooltip component

**How to test:**
- Pull and checkout branch using: `git fetch origin && git checkout feature/mapathon-info`
- Install dependencies using: `npm i`
- Start server using `npm start`
- Go to [http://127.0.0.1:3000/mapathon-report/detailed](http://127.0.0.1:3000/mapathon-report/detailed). Submit form data and click on the question mark icons that appear on the task and time stats column headers. 

**Screenshot:**
<img width="1440" alt="tooltips" src="https://user-images.githubusercontent.com/31903212/169509209-268f3eca-df07-4e17-9613-a19a899e047b.png">

Related issues:
- Fixes #90 
