### PR TITLE
Include hashtags filter in user data quality reports

### DIFF
--- a/src/components/download.js
+++ b/src/components/download.js
@@ -8,17 +8,25 @@ import { useDownloadFile } from "../hooks/useDownloadFile";
 import { FormContext } from "../context/formContext";
 import { MapathonReportCSVHeaders } from "./mapathon/constants";
 import { UserGroupReportCSVHeaders } from "./userGroup/constants";
+import { convertStringToArray } from "../utils/formatInputs";
 
-export const DownloadFileLink = ({ username, type, startDate, endDate }) => {
+export const DownloadFileLink = ({
+  username,
+  type,
+  startDate,
+  endDate,
+  hashtags,
+}) => {
   const fetchFile = () => {
     const body = {
       fromTimestamp: startDate,
       toTimestamp: endDate,
       osmUsernames: [username],
-      issueTypes: ["badgeom"],
+      issueTypes: ["all"],
       outputType: type,
+      hashtags: convertStringToArray(hashtags),
     };
-    return axios.post(`${API_URL}/data-quality/user-reports`, body);
+    return axios.post(`${API_URL}/data-quality/user-reports/`, body);
   };
 
   const getFileName = () => {
@@ -71,6 +79,7 @@ export const DownloadDataCell = ({ value, source }) => {
         type={"csv"}
         startDate={formData.startDate}
         endDate={formData.endDate}
+        hashtags={formData.mapathonHashtags}
       />
       /
       <DownloadFileLink
@@ -78,6 +87,7 @@ export const DownloadDataCell = ({ value, source }) => {
         type={"geojson"}
         startDate={formData.startDate}
         endDate={formData.endDate}
+        hashtags={formData.mapathonHashtags}
       />
     </>
   );


### PR DESCRIPTION
After the enhancement in the API -> https://github.com/hotosm/galaxy-api/pull/229, we can filter the user data quality reports using mapathon hashtags. 

This PR improves the functionality on the frontend making the request to include hashtags in the request body. It also changes the issue type from specifically "bad geometry" to "all" so the user can get all the different types of data quality issues. 