### PR TITLE
Handle single character words

### DIFF
--- a/src/utils/formatInputs.js
+++ b/src/utils/formatInputs.js
@@ -15,13 +15,11 @@ export const convertStringToNumberArray = (input) => {
 export const convertStringToArray = (input) => {
   let result = [];
   if (input.length > 0) {
-    let arr = input.split(",").map((i) => {
+    result = input.split(",").map((i) => {
       i = i.toString().trim();
       if (i.startsWith("#")) i = i.substr(1);
       return i;
     });
-    let pattern = /([a-zA-Z0-9])\w+/gi;
-    result = arr.filter((j) => j.match(pattern));
   }
   return result;
 };


### PR DESCRIPTION
This PR removes the regex pattern that only allows for multiple-character words. Now single-character usernames can be tested.

**How to test:**
- Type in single character usernames in the user group report to retrieve stats if any. 

**Related issues:**
- Fixes #111

**Screenshot:** 
<img width="1411" alt="usergroup report" src="https://user-images.githubusercontent.com/31903212/176663977-3fa47692-bb6c-451b-8bd4-a2901bece154.png">


