### PR TITLE
Update Galaxy API link on About page and all endpoints

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,6 @@
 export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN || "";
-export const API_URL = process.env.REACT_APP_API_URL || "http://127.0.0.1:8000";
+export const API_URL =
+  process.env.REACT_APP_API_URL || "http://127.0.0.1:8000/v1";
 export const MATOMO_ID = process.env.REACT_APP_MATOMO_ID || "";
 export const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN || "";
 export const SENTRY_SAMPLE_RATE =

--- a/src/queries/getLoginUrl.js
+++ b/src/queries/getLoginUrl.js
@@ -2,6 +2,6 @@ import axios from "axios";
 import { API_URL } from "../config";
 
 export const getLoginURL = async () => {
-  const { data } = await axios.get(`${API_URL}/auth/login`);
+  const { data } = await axios.get(`${API_URL}/auth/login/`);
   return data;
 };

--- a/src/queries/getMapathonReport.js
+++ b/src/queries/getMapathonReport.js
@@ -20,7 +20,7 @@ const formatMapathonRequestData = (requestData) => {
 export const getMapathonSummaryReport = async (requestData) => {
   let body = formatMapathonRequestData(requestData);
 
-  const { data } = await axios.post(`${API_URL}/mapathon/summary`, body);
+  const { data } = await axios.post(`${API_URL}/mapathon/summary/`, body);
   return data;
 };
 
@@ -33,6 +33,10 @@ export const getMapathonDetailedReport = async (requestData) => {
   };
   let body = formatMapathonRequestData(requestData);
 
-  const { data } = await axios.post(`${API_URL}/mapathon/detail`, body, config);
+  const { data } = await axios.post(
+    `${API_URL}/mapathon/detail/`,
+    body,
+    config
+  );
   return data;
 };

--- a/src/queries/getUserStats.js
+++ b/src/queries/getUserStats.js
@@ -9,7 +9,7 @@ export const getUserIds = async (requestData) => {
     fromTimestamp: startDate.toISOString(),
     toTimestamp: endDate.toISOString(),
   };
-  const { data } = await axios.post(`${API_URL}/osm-users/ids`, userBody);
+  const { data } = await axios.post(`${API_URL}/osm-users/ids/`, userBody);
   return data;
 };
 
@@ -22,6 +22,6 @@ export const getUserStats = async (id, requestData) => {
     projectIds: [],
     hashtags: convertStringToArray(mapathonHashtags),
   };
-  const { data } = await axios.post(`${API_URL}/osm-users/statistics`, body);
+  const { data } = await axios.post(`${API_URL}/osm-users/statistics/`, body);
   return data;
 };

--- a/src/utils/authUtils.js
+++ b/src/utils/authUtils.js
@@ -10,12 +10,12 @@ function createPopup(title: string = "Authentication", location: string) {
 
 export const createLoginWindow = (redirectTo) => {
   const popup = createPopup("OSM Auth", "");
-  let url = `${API_URL}/auth/login`;
+  let url = `${API_URL}/auth/login/`;
   axios.get(url).then((response) => {
     popup.location = response.data.url;
 
     window.authComplete = (code) => {
-      let callbackUrl = `${API_URL}/auth/callback?code=${code}`;
+      let callbackUrl = `${API_URL}/auth/callback/?code=${code}`;
       axios.get(callbackUrl).then((res) => {
         const params = new URLSearchParams({
           access_token: res.data.access_token,

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -69,11 +69,11 @@ export function About() {
                 </li>
                 <li className="document-link">
                   <a
-                    href="https://osm-stats.hotosm.org/docs"
+                    href="https://galaxy-api.hotosm.org/v1/docs"
                     target="_blank"
                     rel="noreferrer"
                   >
-                    <FormattedMessage {...messages.osmStatsDoc} />
+                    <FormattedMessage {...messages.galaxyAPIDocs} />
                   </a>
                 </li>
                 <li className="document-link">
@@ -121,7 +121,8 @@ export function About() {
                     <FormattedMessage {...messages.workingGroupRegistration} />
                   </a>
                 </li>
-                <li className="document-link">
+                {/* Removing the data download link till automatic dumps are worked on */}
+                {/* <li className="document-link">
                   <a
                     href="https://osm-stats.hotosm.org/data/download/galaxy"
                     target="_blank"
@@ -129,7 +130,7 @@ export function About() {
                   >
                     <FormattedMessage {...messages.osmStatsDownload} />
                   </a>
-                </li>
+                </li> */}
                 <li className="document-link">
                   <a href="h#" target="_blank" rel="noreferrer">
                     <FormattedMessage {...messages.galaxyFAQ} />

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -69,7 +69,7 @@ export function About() {
                 </li>
                 <li className="document-link">
                   <a
-                    href="https://galaxy-api.hotosm.org/v1/docs"
+                    href="https://galaxy-api.hotosm.org/v1/redoc"
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/src/views/messages.js
+++ b/src/views/messages.js
@@ -55,9 +55,9 @@ export default defineMessages({
     id: "about.galaxy.resources.slideDeck",
     defaultMessage: "User Stories for Galaxy",
   },
-  osmStatsDoc: {
+  galaxyAPIDocs: {
     id: "about.galaxy.resources.slideDeck",
-    defaultMessage: "OSM Statistics API Access",
+    defaultMessage: "Galaxy API Access",
   },
   underpassOverview: {
     id: "about.galaxy.resources.underpass.overview",


### PR DESCRIPTION
**What does this PR do?**
- Fixes #115 

**How to test:** 
- Go to the About page. Click on Galaxy API Access to get redirected to the API docs.

**Screenshot**
<img width="1440" alt="api-link" src="https://user-images.githubusercontent.com/31903212/176667664-451f7a5a-9442-47ad-9409-4f71628df525.png">
 