### PR TITLE
Show recency of data on the mapathon and user group pages

### DIFF
--- a/src/assets/svgIcons/info.js
+++ b/src/assets/svgIcons/info.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+// Icon produced by FontAwesome project: https://github.com/FortAwesome/Font-Awesome/
+// License: CC-By 4.0
+
+export class InfoIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 512 512"
+        {...this.props}
+      >
+        <path
+          fill="currentColor"
+          d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 128c17.67 0 32 14.33 32 32c0 17.67-14.33 32-32 32S224 177.7 224 160C224 142.3 238.3 128 256 128zM296 384h-80C202.8 384 192 373.3 192 360s10.75-24 24-24h16v-64H224c-13.25 0-24-10.75-24-24S210.8 224 224 224h32c13.25 0 24 10.75 24 24v88h16c13.25 0 24 10.75 24 24S309.3 384 296 384z"
+        ></path>
+      </svg>
+    );
+  }
+}

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { Link } from "react-router-dom";
+import { InfoIcon } from "../assets/svgIcons/info";
 
 export function Card({ label, summary, route }) {
   return (
@@ -16,3 +17,15 @@ export function Card({ label, summary, route }) {
     </div>
   );
 }
+
+export const InfoCard = ({ info, styles }) => {
+  return (
+    <div className={`flex flex-row ${styles}`}>
+      <InfoIcon className="w-6 h-6 text-blue-grey" />
+      &nbsp;
+      <p className="text-base text-blue-grey font-normal">
+        Last update: <span className="font-medium">{info}</span>
+      </p>
+    </div>
+  );
+};

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -14,6 +14,7 @@ import {
 import { DownloadCSVButton } from "../download";
 import { Tooltip } from "../tooltip";
 import { InfoCard } from "../card";
+import { InfoIcon } from "../../assets/svgIcons/info";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -72,7 +73,8 @@ export const MapathonSummaryResults = ({ data }) => {
 export function MapathonDetailedResultsTable({
   columns,
   data,
-  lastUpdateTime,
+  mapathonUpdateTime,
+  dataQualityUpdateTime,
 }) {
   const intl = useIntl();
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -95,7 +97,7 @@ export function MapathonDetailedResultsTable({
           </Error>
         )}
         <div className="flex justify-between">
-          <InfoCard info={lastUpdateTime} styles={"m-4"} />
+          <InfoCard info={mapathonUpdateTime} styles={"m-4"} />
           <DownloadCSVButton data={data} source={"mapathon"} />
         </div>
         <div className="flex flex-col">
@@ -112,6 +114,7 @@ export function MapathonDetailedResultsTable({
                           "timeSpentValidating",
                           "validatedTasks",
                           "mappedTasks",
+                          "userId",
                         ];
                         let showTooltip = tooltipKeys.includes(column.id);
                         return (
@@ -127,11 +130,22 @@ export function MapathonDetailedResultsTable({
                               {showTooltip ? (
                                 <Tooltip
                                   position={"top center"}
-                                  content={intl.formatMessage(
-                                    messages.mapathonTooltip
-                                  )}
+                                  content={
+                                    column.id === "userId"
+                                      ? intl.formatMessage(
+                                          messages.dataQualityTooltip,
+                                          { dataQualityUpdateTime }
+                                        )
+                                      : intl.formatMessage(
+                                          messages.mapathonTooltip
+                                        )
+                                  }
                                 >
-                                  <QuestionIcon className="w-3 h-3 text-red" />
+                                  {column.id === "userId" ? (
+                                    <InfoIcon className="w-3 h-3 text-red" />
+                                  ) : (
+                                    <QuestionIcon className="w-3 h-3 text-red" />
+                                  )}
                                 </Tooltip>
                               ) : (
                                 ""

--- a/src/components/mapathon/mapathonResults.js
+++ b/src/components/mapathon/mapathonResults.js
@@ -13,6 +13,7 @@ import {
 } from "../../assets/svgIcons";
 import { DownloadCSVButton } from "../download";
 import { Tooltip } from "../tooltip";
+import { InfoCard } from "../card";
 
 const FeatureList = ({ title, features }) => {
   return (
@@ -68,7 +69,11 @@ export const MapathonSummaryResults = ({ data }) => {
   );
 };
 
-export function MapathonDetailedResultsTable({ columns, data }) {
+export function MapathonDetailedResultsTable({
+  columns,
+  data,
+  lastUpdateTime,
+}) {
   const intl = useIntl();
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
@@ -89,7 +94,10 @@ export function MapathonDetailedResultsTable({ columns, data }) {
             <MapathonErrorMessage error={downloadError} />
           </Error>
         )}
-        <DownloadCSVButton data={data} source={"mapathon"} />
+        <div className="flex justify-between">
+          <InfoCard info={lastUpdateTime} styles={"m-4"} />
+          <DownloadCSVButton data={data} source={"mapathon"} />
+        </div>
         <div className="flex flex-col">
           <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 inline-block min-w-full sm:px-6 lg:px-8">

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -197,6 +197,10 @@ export default defineMessages({
     defaultMessage:
       "The following statistics: tasks mapped, tasks validated, time spent mapping, and time spent validating are derived using either Tasking Manager project ids or Tasking Manager specific hashtags, e.g. hotosm-project-1.",
   },
+  dataQualityTooltip: {
+    id: "reports.data_quality.tooltip",
+    defaultMessage: "This data was last updated {dataQualityUpdateTime}.",
+  },
   footerOrganisation: {
     id: "about.footer.organisation",
     defaultMessage: "This project is under development by {OrganisationLink}.",

--- a/src/components/userGroup/messages.js
+++ b/src/components/userGroup/messages.js
@@ -62,6 +62,10 @@ export default defineMessages({
     id: "reports.user.group.table.column.dataQualityIssues",
     defaultMessage: "Data Quality Issues",
   },
+  dataQualityTooltip: {
+    id: "reports.data_quality.tooltip",
+    defaultMessage: "This data was last updated {dataQualityUpdateTime}.",
+  },
   noDataFound: {
     id: "reports.user.group.results.no.data",
     defaultMessage: "No Data Found!",

--- a/src/components/userGroup/userGroupResults.js
+++ b/src/components/userGroup/userGroupResults.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { useTable, useSortBy } from "react-table";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import ReactPlaceholder from "react-placeholder";
 import messages from "./messages";
 import { Error } from "../formResponses";
@@ -14,6 +14,8 @@ import {
 } from "../../assets/svgIcons";
 import { DownloadCSVButton } from "../download";
 import { InfoCard } from "../card";
+import { InfoIcon } from "../../assets/svgIcons/info";
+import { Tooltip } from "../tooltip";
 import "react-placeholder/lib/reactPlaceholder.css";
 
 export function UserGroupResultsTable({
@@ -21,7 +23,8 @@ export function UserGroupResultsTable({
   data,
   userDataCheck,
   loading,
-  lastUpdateTime,
+  userStatsUpdateTime,
+  dataQualityUpdateTime,
 }) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
@@ -31,7 +34,7 @@ export function UserGroupResultsTable({
       },
       useSortBy
     );
-
+  const intl = useIntl();
   const downloadError = useSelector((state) => state.mapathon.downloadError);
 
   if (userDataCheck) {
@@ -51,7 +54,7 @@ export function UserGroupResultsTable({
             className="mt-20 mx-4"
           >
             <div className="w-11/12 mx-auto flex justify-between">
-              <InfoCard info={lastUpdateTime} styles={"my-4"} />
+              <InfoCard info={userStatsUpdateTime} styles={"my-4"} />
               <DownloadCSVButton data={data} source={"userGroup"} />
             </div>
             <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -71,6 +74,19 @@ export function UserGroupResultsTable({
                           >
                             <span className="inline ">
                               {column.render("Header")} &nbsp;
+                              {column.id === "userId" ? (
+                                <Tooltip
+                                  position={"top center"}
+                                  content={intl.formatMessage(
+                                    messages.dataQualityTooltip,
+                                    { dataQualityUpdateTime }
+                                  )}
+                                >
+                                  <InfoIcon className="w-3 h-3 text-red" />
+                                </Tooltip>
+                              ) : (
+                                ""
+                              )}
                               {column.canSort &&
                                 (column.isSorted ? (
                                   column.isSortedDesc ? (

--- a/src/components/userGroup/userGroupResults.js
+++ b/src/components/userGroup/userGroupResults.js
@@ -13,6 +13,7 @@ import {
   SpinnerIcon,
 } from "../../assets/svgIcons";
 import { DownloadCSVButton } from "../download";
+import { InfoCard } from "../card";
 import "react-placeholder/lib/reactPlaceholder.css";
 
 export function UserGroupResultsTable({
@@ -20,6 +21,7 @@ export function UserGroupResultsTable({
   data,
   userDataCheck,
   loading,
+  lastUpdateTime,
 }) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
@@ -48,7 +50,8 @@ export function UserGroupResultsTable({
             rows={8}
             className="mt-20 mx-4"
           >
-            <div className="w-11/12 mx-auto">
+            <div className="w-11/12 mx-auto flex justify-between">
+              <InfoCard info={lastUpdateTime} styles={"my-4"} />
               <DownloadCSVButton data={data} source={"userGroup"} />
             </div>
             <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">

--- a/src/queries/getDataRecency.js
+++ b/src/queries/getDataRecency.js
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { API_URL } from "../config";
+
+export const getDataRecency = async (requestData) => {
+  const { source, output } = requestData;
+  let requestBody = {
+    dataSource: source,
+    dataOutput: output,
+  };
+  const { data } = await axios.post(`${API_URL}/status/`, requestBody);
+  return data;
+};

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -1,3 +1,5 @@
+import { formatDuration } from "date-fns";
+
 export const getTimeZone = (date) => {
   const offset = date.getTimezoneOffset();
   const absoluteValue = Math.abs(offset);
@@ -15,14 +17,46 @@ const convertToSeconds = (time) => {
   const secondsInHour = 60 * 60;
   const secondsInMinute = 60;
   const totalSeconds =
-    +hours * secondsInHour + +minutes * secondsInMinute + +seconds;
+    parseInt(hours) * secondsInHour +
+    parseInt(minutes) * secondsInMinute +
+    parseFloat(seconds);
   return totalSeconds;
 };
 
 export const formatDurationOutput = (time) => {
   const timeInSeconds = convertToSeconds(time);
-  if (timeInSeconds > 0) {
-    return `${Number(timeInSeconds).toFixed(2)} seconds ago`;
+  if (timeInSeconds > 1) {
+    const intervals = {
+      seconds: 0,
+      minutes: 0,
+      hours: 0,
+      days: 0,
+      weeks: 0,
+      months: 0,
+      years: 0,
+    };
+    const durationSplitArray = time.split(",");
+    // split time into hours, minutes and seconds
+    const lastArrayElement = durationSplitArray[durationSplitArray.length - 1];
+    const [hours, minutes, seconds] = lastArrayElement.split(":");
+    intervals["hours"] = parseInt(hours);
+    intervals["minutes"] = parseInt(minutes);
+    intervals["seconds"] = parseInt(seconds);
+    // further split into days, weeks, months, years - if available
+    if (durationSplitArray.length > 1) {
+      for (let i = 0; i < durationSplitArray.length - 1; i++) {
+        const intervalSplit = durationSplitArray[i].trim().split(" ");
+        if (intervalSplit[1].includes("day"))
+          intervals["days"] = parseInt(intervalSplit[0]);
+        if (intervalSplit[1].includes("week"))
+          intervals["weeks"] = parseInt(intervalSplit[0]);
+        if (intervalSplit[1].includes("month"))
+          intervals["months"] = parseInt(intervalSplit[0]);
+        if (intervalSplit[1].includes("year"))
+          intervals["years"] = parseInt(intervalSplit[0]);
+      }
+    }
+    return `${formatDuration(intervals)} ago`;
   } else {
     return "less than a second ago";
   }

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -8,3 +8,22 @@ export const getTimeZone = (date) => {
 
   return `UTC${symbol}${hours}:${minutes}`;
 };
+
+const convertToSeconds = (time) => {
+  if (!time) return null;
+  const [hours, minutes, seconds] = time.split(":");
+  const secondsInHour = 60 * 60;
+  const secondsInMinute = 60;
+  const totalSeconds =
+    +hours * secondsInHour + +minutes * secondsInMinute + +seconds;
+  return totalSeconds;
+};
+
+export const formatDurationOutput = (time) => {
+  const timeInSeconds = convertToSeconds(time);
+  if (timeInSeconds > 0) {
+    return `${Number(timeInSeconds).toFixed(2)} seconds ago`;
+  } else {
+    return "less than a second ago";
+  }
+};

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -66,7 +66,8 @@ export const MapathonSummaryReport = (props) => {
 };
 
 export const MapathonDetailedReport = () => {
-  const [lastUpdateTime, setLastUpdateTime] = useState(null);
+  const [mapathonUpdateTime, setMapathonUpdateTime] = useState(null);
+  const [dataQualityUpdateTime, setDataQualityUpdateTime] = useState(null);
   const { mutate, data, isLoading, error } = useMutation(
     getMapathonDetailedReport,
     {}
@@ -75,12 +76,19 @@ export const MapathonDetailedReport = () => {
 
   useEffect(() => {
     if (data) {
-      const params = {
+      const mapathonParams = {
         source: "insight",
         output: "mapathon_statistics",
       };
-      getDataRecency(params).then((res) => {
-        setLastUpdateTime(res["time_difference"]);
+      const dataQualityParams = {
+        source: "underpass",
+        output: "data_quality",
+      };
+      getDataRecency(mapathonParams).then((res) => {
+        setMapathonUpdateTime(res["time_difference"]);
+      });
+      getDataRecency(dataQualityParams).then((res) => {
+        setDataQualityUpdateTime(res["time_difference"]);
       });
     }
   }, [data]);
@@ -109,7 +117,8 @@ export const MapathonDetailedReport = () => {
         <MapathonDetailedResultsTable
           data={aggregateMapathonUserData(data)}
           columns={MapathonDetailedTableHeaders}
-          lastUpdateTime={formatDurationOutput(lastUpdateTime)}
+          mapathonUpdateTime={formatDurationOutput(mapathonUpdateTime)}
+          dataQualityUpdateTime={formatDurationOutput(dataQualityUpdateTime)}
         />
       )}
     </div>

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMutation } from "react-query";
 import { MapathonReportForm } from "../components/mapathon/mapathonReportForm";
@@ -16,6 +17,8 @@ import { MiniNavBar } from "../components/nav/navbar";
 import { aggregateMapathonUserData } from "../utils/mapathonDataUtils";
 import { MapathonDetailedTableHeaders } from "../components/mapathon/constants";
 import { SpinnerIcon } from "../assets/svgIcons";
+import { getDataRecency } from "../queries/getDataRecency";
+import { formatDurationOutput } from "../utils/timeUtils";
 
 const MAPATHON_PAGES = [
   { pageTitle: "Mapathon Summary Report", pageURL: "/mapathon-report/summary" },
@@ -63,11 +66,24 @@ export const MapathonSummaryReport = (props) => {
 };
 
 export const MapathonDetailedReport = () => {
+  const [lastUpdateTime, setLastUpdateTime] = useState(null);
   const { mutate, data, isLoading, error } = useMutation(
     getMapathonDetailedReport,
     {}
   );
   const triggeredLoading = useSelector((state) => state.mapathon.isLoading);
+
+  useEffect(() => {
+    if (data) {
+      const params = {
+        source: "insight",
+        output: "mapathon_statistics",
+      };
+      getDataRecency(params).then((res) => {
+        setLastUpdateTime(res["time_difference"]);
+      });
+    }
+  }, [data]);
 
   return (
     <div>
@@ -93,6 +109,7 @@ export const MapathonDetailedReport = () => {
         <MapathonDetailedResultsTable
           data={aggregateMapathonUserData(data)}
           columns={MapathonDetailedTableHeaders}
+          lastUpdateTime={formatDurationOutput(lastUpdateTime)}
         />
       )}
     </div>

--- a/src/views/UserGroupReport.js
+++ b/src/views/UserGroupReport.js
@@ -22,7 +22,8 @@ export const UserGroupReport = () => {
   const [formError, setFormError] = useState(null);
   const [userIds, setUserIds] = useState([]);
   const [users, setUsers] = useState();
-  const [lastUpdateTime, setLastUpdateTime] = useState(null);
+  const [userStatsUpdateTime, setUserStatsUpdateTime] = useState(null);
+  const [dataQualityUpdateTime, setDataQualityUpdateTime] = useState(null);
 
   const { mutate, data, isLoading, error } = useMutation(getUserIds);
 
@@ -65,12 +66,20 @@ export const UserGroupReport = () => {
   useEffect(() => {
     if (userIds) {
       fetchUserStats(userIds);
-      const params = {
+
+      const userStatsParams = {
         source: "insight",
         output: "user_statistics",
       };
-      getDataRecency(params).then((res) => {
-        setLastUpdateTime(res["time_difference"]);
+      const dataQualityParams = {
+        source: "underpass",
+        output: "data_quality",
+      };
+      getDataRecency(userStatsParams).then((res) => {
+        setUserStatsUpdateTime(res["time_difference"]);
+      });
+      getDataRecency(dataQualityParams).then((res) => {
+        setDataQualityUpdateTime(res["time_difference"]);
       });
     }
   }, [userIds]);
@@ -98,7 +107,8 @@ export const UserGroupReport = () => {
           data={aggregateUserGroupData(users)}
           userDataCheck={userIds && userIds.length > 0}
           loading={userIds.length !== users.length}
-          lastUpdateTime={formatDurationOutput(lastUpdateTime)}
+          userStatsUpdateTime={formatDurationOutput(userStatsUpdateTime)}
+          dataQualityUpdateTime={formatDurationOutput(dataQualityUpdateTime)}
         />
       )}
     </div>

--- a/src/views/UserGroupReport.js
+++ b/src/views/UserGroupReport.js
@@ -10,6 +10,8 @@ import { MiniNavBar } from "../components/nav/navbar";
 import { UserGroupColumnHeadings } from "../components/userGroup/constants";
 import { aggregateUserGroupData } from "../utils/userGroupUtils";
 import { SpinnerIcon } from "../assets/svgIcons";
+import { getDataRecency } from "../queries/getDataRecency";
+import { formatDurationOutput } from "../utils/timeUtils";
 
 const userGroupPage = [
   { pageTitle: "User Group Report", pageURL: "/user-report" },
@@ -20,6 +22,7 @@ export const UserGroupReport = () => {
   const [formError, setFormError] = useState(null);
   const [userIds, setUserIds] = useState([]);
   const [users, setUsers] = useState();
+  const [lastUpdateTime, setLastUpdateTime] = useState(null);
 
   const { mutate, data, isLoading, error } = useMutation(getUserIds);
 
@@ -62,6 +65,13 @@ export const UserGroupReport = () => {
   useEffect(() => {
     if (userIds) {
       fetchUserStats(userIds);
+      const params = {
+        source: "insight",
+        output: "user_statistics",
+      };
+      getDataRecency(params).then((res) => {
+        setLastUpdateTime(res["time_difference"]);
+      });
     }
   }, [userIds]);
 
@@ -88,6 +98,7 @@ export const UserGroupReport = () => {
           data={aggregateUserGroupData(users)}
           userDataCheck={userIds && userIds.length > 0}
           loading={userIds.length !== users.length}
+          lastUpdateTime={formatDurationOutput(lastUpdateTime)}
         />
       )}
     </div>


### PR DESCRIPTION
**What does this PR do?**
- Fixes #86

**Details:**
- The recency of data is shown on the mapathon detailed page, user group reports page, and the data quality columns for each of those pages as well. 
- Separate API calls are made to get the time difference, i.e. time since the last update. The time is then converted to a readable format, e.g 12 hours ago and shown on the site. If the total time is less than 1 second, it shows `less than a second ago`.

**How to test:**
- Fetch and check out branch using `git fetch origin && git checkout feature/data-recency`
- Install dependencies using `npm i`
- Start server `npm start`
- API URL = `http://127.0.0.1:8000/v1/`
- Go to `http://127.0.0.1:3000/user-report` or `http://127.0.0.1:3000/mapathon-report/detailed` and make a request. You should be able to see the recency of the stats above the results table, as well as the data quality recency tooltip by hovering over the info icon.

**Screenshots:**
Last updated section and data quality tooltip:
![partial shot](https://user-images.githubusercontent.com/31903212/183095852-f469a5ac-2474-462b-980a-8bfaae1bf84d.png)

![full shot - data recency](https://user-images.githubusercontent.com/31903212/183095876-83209f60-9f46-473c-86d0-4f73b9acd120.png)

 