### PR TITLE
Handle submit button during query fetch

### DIFF
--- a/src/components/mapathon/mapathonReportForm.js
+++ b/src/components/mapathon/mapathonReportForm.js
@@ -12,6 +12,7 @@ import { setLoading, setTriggerSubmit } from "../../features/form/formSlice";
 import { FormContext } from "../../context/formContext";
 import { getTimeZone } from "../../utils/timeUtils";
 import { validateMapathonFormData } from "../../utils/validationUtils";
+import { SpinnerIcon } from "../../assets/svgIcons";
 import messages from "../messages";
 
 export const MapathonReportForm = ({ fetch, error, loading }) => {
@@ -172,14 +173,22 @@ export const MapathonReportForm = ({ fetch, error, loading }) => {
             />
           </div>
         </div>
-        <div className="text-center mt-4">
-          <SubmitButton
-            styles="bg-red text-white py-3 px-10 text-xl"
-            disabled={loading}
-          >
-            <FormattedMessage {...messages.mapathonSubmitForm} />
-          </SubmitButton>
-        </div>
+        {!loading && (
+          <div className="text-center mt-4">
+            <SubmitButton
+              styles="bg-red text-white py-3 px-10 text-xl"
+              disabled={loading}
+            >
+              <FormattedMessage {...messages.mapathonSubmitForm} />
+            </SubmitButton>
+          </div>
+        )}
+        {loading && (
+          <div className="mx-auto text-center w-1/4 p-1 mt-5">
+            <SpinnerIcon className="animate-spin w-5 h-5 mr-2 mb-1 inline text-red" />
+            Loading...
+          </div>
+        )}
       </form>
       {formError && (
         <Error>

--- a/src/components/userGroup/userGroupForm.js
+++ b/src/components/userGroup/userGroupForm.js
@@ -7,6 +7,7 @@ import { SubmitButton } from "../button";
 import { Error } from "../formResponses";
 import { UserGroupErrorMessage } from "./userGroupError";
 import { getTimeZone } from "../../utils/timeUtils";
+import { SpinnerIcon } from "../../assets/svgIcons";
 import messages from "./messages";
 
 export const UserGroupReportForm = ({
@@ -16,6 +17,8 @@ export const UserGroupReportForm = ({
   setUsers,
   formError,
   setFormError,
+  setLoading,
+  loading,
 }) => {
   const intl = useIntl();
 
@@ -34,6 +37,7 @@ export const UserGroupReportForm = ({
     event.preventDefault();
     if (formData.usernames.length > 0) {
       setUsers([]);
+      setLoading(true);
       fetch(formData); // API call
       setFormError(null);
     } else {
@@ -124,11 +128,19 @@ export const UserGroupReportForm = ({
             />
           </div>
         </div>
-        <div className="text-center mt-4">
-          <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">
-            <FormattedMessage {...messages.Submit} />
-          </SubmitButton>
-        </div>
+        {!loading && (
+          <div className="text-center mt-4">
+            <SubmitButton styles="bg-red text-white py-3 px-10 text-xl">
+              <FormattedMessage {...messages.Submit} />
+            </SubmitButton>
+          </div>
+        )}
+        {loading && (
+          <div className="mx-auto text-center w-1/4 p-1 mt-5">
+            <SpinnerIcon className="animate-spin w-5 h-5 mr-2 mb-1 inline text-red" />
+            Loading...
+          </div>
+        )}
       </form>
       {formError && (
         <Error>

--- a/src/components/userGroup/userGroupResults.js
+++ b/src/components/userGroup/userGroupResults.js
@@ -19,7 +19,7 @@ export function UserGroupResultsTable({
   columns,
   data,
   userDataCheck,
-  loading,
+  tableLoading,
 }) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
@@ -104,7 +104,7 @@ export function UserGroupResultsTable({
                     })}
                   </tbody>
                 </table>
-                {loading ? (
+                {tableLoading ? (
                   <div className="text-center w-11/12 mx-auto">
                     <SpinnerIcon className="animate-spin w-5 h-5 mt-2 inline text-red" />
                   </div>

--- a/src/views/MapathonReports.js
+++ b/src/views/MapathonReports.js
@@ -15,7 +15,6 @@ import { setTriggerSubmit } from "../features/form/formSlice";
 import { MiniNavBar } from "../components/nav/navbar";
 import { aggregateMapathonUserData } from "../utils/mapathonDataUtils";
 import { MapathonDetailedTableHeaders } from "../components/mapathon/constants";
-import { SpinnerIcon } from "../assets/svgIcons";
 
 const MAPATHON_PAGES = [
   { pageTitle: "Mapathon Summary Report", pageURL: "/mapathon-report/summary" },
@@ -51,12 +50,6 @@ export const MapathonSummaryReport = (props) => {
       <div className="text-center mt-4">
         <MapathonRedirectButton triggerFn={triggeredSubmit} />
       </div>
-      {isLoading && (
-        <div className="mx-auto text-center w-1/4 p-1 mt-5">
-          <SpinnerIcon className="animate-spin w-5 h-5 mr-2 mb-1 inline text-red" />
-          Loading...
-        </div>
-      )}
       {data && <MapathonSummaryResults data={data} />}
     </div>
   );
@@ -83,12 +76,6 @@ export const MapathonDetailedReport = () => {
         fetch={mutate}
         loading={isLoading || triggeredLoading}
       />
-      {(isLoading || triggeredLoading) && (
-        <div className="mx-auto text-center w-1/4 p-1 mt-5">
-          <SpinnerIcon className="animate-spin w-5 h-5 mr-2 mb-1 inline text-red" />
-          Loading...
-        </div>
-      )}
       {data && (
         <MapathonDetailedResultsTable
           data={aggregateMapathonUserData(data)}


### PR DESCRIPTION
**What does this PR do?** 
- After a person has submitted a query via the mapathon report pages and/or user group report page, the button is now replaced with a loading spinner until the API calls are done and a response is got. 

**Issues:**
- Fixes #120 

**How to test:** 
- Fetch and checkout the branch using `git fetch origin && git checkout fix/button-interactivity`
- Start the server using `npm start`
- Go to either the mapathon or user group report pages and test with any query. 
- After hitting submit, the button is replaced with a spinner. When the results are back, the submit button reappers. 

**Screenshot:**
![submit button handling](https://user-images.githubusercontent.com/31903212/184336991-46b61c04-a3fc-4b4e-8de3-08d827248b00.png)

